### PR TITLE
Print exception + bug report link + remove double print out in catalina.out

### DIFF
--- a/gui/jsp/footer.jspf
+++ b/gui/jsp/footer.jspf
@@ -17,4 +17,4 @@
   <td height="17%" colspan="2" valign="bottom">&nbsp;</td>
 </tr>
 <!-- T1_Row4 end -->
-<div id='hcalfmVersion'>HCALFM version: 05-12-16_v4</div>
+<div id='hcalfmVersion'>HCALFM version: 05-12-16_v5</div>

--- a/gui/jsp/footer.jspf
+++ b/gui/jsp/footer.jspf
@@ -17,4 +17,4 @@
   <td height="17%" colspan="2" valign="bottom">&nbsp;</td>
 </tr>
 <!-- T1_Row4 end -->
-<div id='hcalfmVersion'>HCALFM version: 05-09-16_v1</div>
+<div id='hcalfmVersion'>HCALFM version: 05-12-16_v3</div>

--- a/gui/jsp/footer.jspf
+++ b/gui/jsp/footer.jspf
@@ -17,4 +17,4 @@
   <td height="17%" colspan="2" valign="bottom">&nbsp;</td>
 </tr>
 <!-- T1_Row4 end -->
-<div id='hcalfmVersion'>HCALFM version: 05-03-16_v3</div>
+<div id='hcalfmVersion'>HCALFM version: 05-09-16_v1</div>

--- a/gui/jsp/footer.jspf
+++ b/gui/jsp/footer.jspf
@@ -17,4 +17,4 @@
   <td height="17%" colspan="2" valign="bottom">&nbsp;</td>
 </tr>
 <!-- T1_Row4 end -->
-<div id='hcalfmVersion'>HCALFM version: 05-12-16_v3</div>
+<div id='hcalfmVersion'>HCALFM version: 05-12-16_v4</div>

--- a/gui/jsp/header.jsp
+++ b/gui/jsp/header.jsp
@@ -23,14 +23,14 @@
 		<!-- Central title end -->
 		
 		<td width="50%" align="right" bgcolor="#EEEEEE">
-				<p id="versionSpot"></p>
-				<p>
-				<!-- Version begin -->
-				<font color="#000099" size="1" face="Arial, Helvetica, sans-serif">
-					Tag : <b><%=getServletContext().getAttribute("version")%></b>
-				</font>
-				<!-- Version end -->
-			</p>
+			<p id="versionSpot"></p>
+			<p>
+			<!-- Version begin -->
+			<font color="#000099" size="1" face="Arial, Helvetica, sans-serif">
+				Tag : <b><%=getServletContext().getAttribute("version")%></b>
+			</font>
+			<!-- Version end -->
+		  </p>
 			<!-- Tag begin -->
 			<%if (request.getRemoteUser() != null) {%>
 			<font size="1" color="#000099" face="Arial, Helvetica, sans-serif">
@@ -39,6 +39,13 @@
 			</font>
 			<%}%>
 			<!-- Tag end -->
+      <p>
+			<!-- Bug-report link begin -->
+			<font color="#000099" size="1" face="Arial, Helvetica, sans-serif">
+				<a href="https://github.com/HCALRunControl/levelOneHCALFM/issues"> File a bug report </a>
+			</font>
+			<!-- Bug-report link  end -->
+		  </p>
 		</td>
 	</tr>
 	<!-- T1_Row1 end -->

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -1295,12 +1295,13 @@ public class HCALEventHandler extends UserEventHandler {
     }
     catch (Exception e) {
       // failed to init
-      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to initialize resources";
-      logger.error(errMessage,e);
-      functionManager.sendCMSError(errMessage);
-      functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
-      functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT(errMessage)));
-      if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return;}
+      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to initialize resources. Caught exception message: "+ e.getMessage();
+      functionManager.goToError(errMessage);
+      //logger.error(errMessage);
+      //functionManager.sendCMSError(errMessage);
+      //functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
+      //functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT(errMessage)));
+      //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return;}
     }
 
     // find xdaq applications

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -33,6 +33,7 @@ import java.util.Scanner;
 import java.util.regex.MatchResult;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.io.PrintWriter;
 
 import net.hep.cms.xdaqctl.XDAQException;
 import net.hep.cms.xdaqctl.XDAQTimeoutException;
@@ -1295,8 +1296,11 @@ public class HCALEventHandler extends UserEventHandler {
     }
     catch (Exception e) {
       // failed to init
-      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to initialize resources. Caught exception message: "+ e.getMessage();
-      functionManager.goToError(errMessage);
+      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to initialize resources. Printing stacktrace to catalina.out.";
+      functionManager.goToError(errMessage,e);
+      StringWriter sw = new StringWriter();
+      e.printStackTrace( new PrintWriter(sw) );
+      System.out.println(sw.toString());
       //logger.error(errMessage);
       //functionManager.sendCMSError(errMessage);
       //functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -1296,11 +1296,11 @@ public class HCALEventHandler extends UserEventHandler {
     }
     catch (Exception e) {
       // failed to init
-      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to initialize resources. Printing stacktrace to catalina.out.";
-      functionManager.goToError(errMessage,e);
       StringWriter sw = new StringWriter();
       e.printStackTrace( new PrintWriter(sw) );
       System.out.println(sw.toString());
+      String errMessage = "[HCAL " + functionManager.FMname + "] " + this.getClass().toString() + " failed to initialize resources. Printing stacktrace: "+ sw.toString();
+      functionManager.goToError(errMessage,e);
       //logger.error(errMessage);
       //functionManager.sendCMSError(errMessage);
       //functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -823,7 +823,8 @@ public class HCALFunctionManager extends UserFunctionManager {
 	 * go to the error state, setting messages and so forth, with exception
 	 */
 	public void goToError(String errMessage, Exception e) {
-		logger.error(errMessage,e);
+    errMessage += " Message from the caught exception is: "+e.getMessage();
+		logger.error(errMessage);
 		sendCMSError(errMessage);
 		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.STATE,new StringT("Error")));
 		getParameterSet().put(new FunctionManagerParameter<StringT>(HCALParameters.ACTION_MSG,new StringT("oops - technical difficulties ..."+errMessage)));

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -280,7 +280,7 @@ public class HCALxmlHandler {
     String newExecXMLstring = "";
     try {
 
-      System.out.println(execXMLstring);
+      //System.out.println(execXMLstring);
       docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
       InputSource inputSource = new InputSource();
       inputSource.setCharacterStream(new StringReader(execXMLstring));


### PR DESCRIPTION
-the goToError function now prints the message from the caught execption
-bug report link in gui
-Stacktrace is printed in logcollector when qg.init() fails with an exception,
-the double printout of excecutive xml in catalina.out comes from a printout line in addStateListenerContext. Commented that.

-This code is at P5.