### PR TITLE
Prevent LV2 from closing SID + stop supervisorWatchThread before destroy

### DIFF
--- a/gui/jsp/footer.jspf
+++ b/gui/jsp/footer.jspf
@@ -15,4 +15,4 @@
   <td colspan="2" valign="bottom">&nbsp;</td>
 </tr>
 <!-- T1_Row4 end -->
-<div id='hcalfmVersion'>HCALFM version: 06-24-16_v2</div>
+<div id='hcalfmVersion'>HCALFM version: 07-08-16_v2</div>

--- a/gui/jsp/footer.jspf
+++ b/gui/jsp/footer.jspf
@@ -15,4 +15,4 @@
   <td colspan="2" valign="bottom">&nbsp;</td>
 </tr>
 <!-- T1_Row4 end -->
-<div id='hcalfmVersion'>HCALFM version: 07-08-16_v2</div>
+<div id='hcalfmVersion'>HCALFM version: 07-13-16_v1</div>

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -547,6 +547,7 @@ public class HCALEventHandler extends UserEventHandler {
   public void destroy() {
     // Stop all threads
     functionManager.parameterSender.shutdown();
+	  logger.info("[Martin log HCAL "+ functionManager.FMname + "]: Going to stop the watchthreads from EventHandler");
     stopMonitorThread = true;
     stopHCALSupervisorWatchThread = true;
     stopTriggerAdapterWatchThread = true;

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -547,7 +547,6 @@ public class HCALEventHandler extends UserEventHandler {
   public void destroy() {
     // Stop all threads
     functionManager.parameterSender.shutdown();
-	  logger.info("[Martin log HCAL "+ functionManager.FMname + "]: Going to stop the watchthreads from EventHandler");
     stopMonitorThread = true;
     stopHCALSupervisorWatchThread = true;
     stopTriggerAdapterWatchThread = true;

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2982,10 +2982,6 @@ public class HCALEventHandler extends UserEventHandler {
 
         icount++;
 
-        // delay between polls
-        try { Thread.sleep(1000); }
-        catch (Exception ignored) { return; }
-
         Date now = Calendar.getInstance().getTime();
 
         // always update the completion status by looping over FM's and Subsystems and update the paramter set
@@ -3128,6 +3124,9 @@ public class HCALEventHandler extends UserEventHandler {
             System.out.println(Message);
           }
         }
+        // delay between polls
+        try { Thread.sleep(1000); }
+        catch (Exception ignored) { return; }
 
       }
 
@@ -3155,10 +3154,6 @@ public class HCALEventHandler extends UserEventHandler {
       while ((stopHCALSupervisorWatchThread == false) && (functionManager != null) && (functionManager.isDestroyed() == false)) {
 
         icount++;
-
-        // delay between polls
-        try { Thread.sleep(1000); }
-        catch (Exception ignored) { return; }
 
         Date now = Calendar.getInstance().getTime();
 
@@ -3222,6 +3217,10 @@ public class HCALEventHandler extends UserEventHandler {
             }
           }
         }
+        // delay between polls
+        try { Thread.sleep(1000); }
+        catch (Exception ignored) { return; }
+
       }
 
       // stop the HCAL supervisor watchdog thread
@@ -3248,10 +3247,6 @@ public class HCALEventHandler extends UserEventHandler {
       while ((stopTriggerAdapterWatchThread == false) && (functionManager != null) && (functionManager.isDestroyed() == false)) {
 
         icount++;
-
-        // delay between polls
-        try { Thread.sleep(1000); }
-        catch (Exception ignored) { return; }
 
         Date now = Calendar.getInstance().getTime();
 
@@ -3343,6 +3338,10 @@ public class HCALEventHandler extends UserEventHandler {
             }
           }
         }
+        // delay between polls
+        try { Thread.sleep(1000); }
+        catch (Exception ignored) { return; }
+
       }
 
       // stop the TriggerAdapter watchdog thread
@@ -3372,10 +3371,6 @@ public class HCALEventHandler extends UserEventHandler {
 
 			// poll alarmer status in the Running/RunningDegraded states every 30 sec to see if it is still OK/alive
       while ((stopAlarmerWatchThread == false) && (functionManager != null) && (functionManager.isDestroyed() == false)) {
-
-        // delay between polls
-        try { Thread.sleep(30000); } // check every 30 seconds
-        catch (Exception ignored) { return; }
 
         Date now = Calendar.getInstance().getTime();
 
@@ -3474,6 +3469,10 @@ public class HCALEventHandler extends UserEventHandler {
 						}
 					}
 				}
+        // delay between polls
+        try { Thread.sleep(30000); } // check every 30 seconds
+        catch (Exception ignored) { return; }
+
 			}
 
 			// stop the HCAL supervisor watchdog thread

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -361,7 +361,7 @@ public class HCALFunctionManager extends UserFunctionManager {
     System.out.println("[HCAL " + FMname + "] destroyAction called");
     logger.info("[HCAL " + FMname + "] destroyAction called");
 
-
+		
     // if RunInfo database is connected try to report the destroying of this FM
     /*if ((HCALRunInfo!=null) && (RunWasStarted)) {
       {
@@ -394,7 +394,7 @@ public class HCALFunctionManager extends UserFunctionManager {
     }*/
 
     // try to close any open session ID only if we are in local run mode i.e. not CDAQ and not miniDAQ runs and if it's a LV1FM
-    if (RunType.equals("local") && containerFMChildren!=null) { closeSessionId(); }
+    if (RunType.equals("local") && !containerFMChildren.isEmpty()) { closeSessionId(); }
 
     // unsubscribe from retrieving XMAS info
     if (XMASMonitoringEnabled) { unsubscribeWSE(); }  
@@ -421,7 +421,12 @@ public class HCALFunctionManager extends UserFunctionManager {
         }
       }
     }
-    logger.info("[Martin log HCAL " +FMname+"]: Going to call destroyXDAQ from functionManger");
+    //Stop watchthreads before destroying
+    theEventHandler.stopMonitorThread = true;
+    theEventHandler.stopHCALSupervisorWatchThread = true;
+    theEventHandler.stopTriggerAdapterWatchThread = true;
+    theEventHandler.stopAlarmerWatchThread = true; 
+
     destroyXDAQ();
 
     destroyed = true;

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -878,7 +878,6 @@ public class HCALFunctionManager extends UserFunctionManager {
     // see if there is an exec with a supervisor and kill it first
     URI supervExecURI = null;
 		if (containerhcalSupervisor != null) {
-			logger.info("[Martin log HCAL "+FMname+"]: Going to kill supervisor");
 			for (QualifiedResource qr : containerhcalSupervisor.getApplications()) {
 				Resource supervResource = containerhcalSupervisor.getApplications().get(0).getResource();
 				XdaqExecutiveResource qrSupervParentExec = ((XdaqApplicationResource)supervResource).getXdaqExecutiveResourceParent();

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -359,7 +359,7 @@ public class HCALFunctionManager extends UserFunctionManager {
     // This method is called by the framework when the Function Manager is destroyed.
 
     System.out.println("[HCAL " + FMname + "] destroyAction called");
-    logger.debug("[HCAL " + FMname + "] destroyAction called");
+    logger.info("[HCAL " + FMname + "] destroyAction called");
 
 
     // if RunInfo database is connected try to report the destroying of this FM

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -394,7 +394,7 @@ public class HCALFunctionManager extends UserFunctionManager {
     }*/
 
     // try to close any open session ID only if we are in local run mode i.e. not CDAQ and not miniDAQ runs
-    if (RunType.equals("local")) { closeSessionId(); }
+    if (RunType.equals("local") && !Level2FM) { closeSessionId(); }
 
     // unsubscribe from retrieving XMAS info
     if (XMASMonitoringEnabled) { unsubscribeWSE(); }  

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -393,8 +393,8 @@ public class HCALFunctionManager extends UserFunctionManager {
     HCALRunInfo = null; // make RunInfo ready for the next round of run info to store
     }*/
 
-    // try to close any open session ID only if we are in local run mode i.e. not CDAQ and not miniDAQ runs
-    if (RunType.equals("local") && !Level2FM) { closeSessionId(); }
+    // try to close any open session ID only if we are in local run mode i.e. not CDAQ and not miniDAQ runs and if it's a LV1FM
+    if (RunType.equals("local") && containerFMChildren!=null) { closeSessionId(); }
 
     // unsubscribe from retrieving XMAS info
     if (XMASMonitoringEnabled) { unsubscribeWSE(); }  

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -421,6 +421,7 @@ public class HCALFunctionManager extends UserFunctionManager {
         }
       }
     }
+    logger.info("[Martin log HCAL " +FMname+"]: Going to call destroyXDAQ from functionManger");
     destroyXDAQ();
 
     destroyed = true;
@@ -724,7 +725,7 @@ public class HCALFunctionManager extends UserFunctionManager {
         logger.warn("[HCAL " + FMname + "] Could not get sessionId for closing session.\nNot closing session.\nThis is OK if no sessionId was requested from within HCAL land, i.e. global runs.",e);
       }
       try {
-        logger.debug("[HCAL " + FMname + "] Trying to close log sessionId = " + sessionId );
+        logger.info("[HCAL " + FMname + "] Trying to close log sessionId = " + sessionId );
         logSessionConnector.closeSession(sessionId);
         logger.debug("[HCAL " + FMname + "] ... closed log sessionId = " + sessionId );
       }
@@ -872,6 +873,7 @@ public class HCALFunctionManager extends UserFunctionManager {
     // see if there is an exec with a supervisor and kill it first
     URI supervExecURI = null;
 		if (containerhcalSupervisor != null) {
+			logger.info("[Martin log HCAL "+FMname+"]: Going to kill supervisor");
 			for (QualifiedResource qr : containerhcalSupervisor.getApplications()) {
 				Resource supervResource = containerhcalSupervisor.getApplications().get(0).getResource();
 				XdaqExecutiveResource qrSupervParentExec = ((XdaqApplicationResource)supervResource).getXdaqExecutiveResourceParent();

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -730,7 +730,7 @@ public class HCALFunctionManager extends UserFunctionManager {
         logger.warn("[HCAL " + FMname + "] Could not get sessionId for closing session.\nNot closing session.\nThis is OK if no sessionId was requested from within HCAL land, i.e. global runs.",e);
       }
       try {
-        logger.info("[HCAL " + FMname + "] Trying to close log sessionId = " + sessionId );
+        logger.debug("[HCAL " + FMname + "] Trying to close log sessionId = " + sessionId );
         logSessionConnector.closeSession(sessionId);
         logger.debug("[HCAL " + FMname + "] ... closed log sessionId = " + sessionId );
       }


### PR DESCRIPTION
Prevent LV2 from closing SID:
Check if the FM has Children before closing SID.

Stop the MonitorWatchThread, SupervisorWatchThread, TriggerAdapterWatchThread, AlarmerWatchThread before destroyXDAQ.
For this to work as expected, I moved the sleep to the end of while loop for these threads such that if the stop_watchthread_boolean is changed during sleep, it will prevent an extra poll of the destroyed supervisor. 

Tested at 904

This PR addresses these two issues:
https://github.com/HCALRunControl/levelOneHCALFM/issues/113
https://github.com/HCALRunControl/levelOneHCALFM/issues/117