### PR TITLE
Evm trig app mask fix

### DIFF
--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -41,22 +41,27 @@ public class HCALMasker {
     boolean hasAdummy = false;
     boolean hasAnEventBuilder = false;
     boolean hasAnFU = false;
+    VectorT<StringT> maskedRss =  (VectorT<StringT>)functionManager.getHCALparameterSet().get("MASKED_RESOURCES").getValue();
+    StringT[] maskedRssArray = maskedRss.toArray(new StringT[maskedRss.size()]);
+
     for (Resource level2resource : level2Children) {
-      if (level2resource.getName().contains("TriggerAdapter") || level2resource.getName().contains("FanoutTTCciTA")) {
-        logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a TA.");
-        hasAtriggerAdapter=true;
-        if (level2resource.getName().contains("DummyTriggerAdapter")) {
-          logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a DummyTriggerAdapter.");
-          hasAdummy=true;
+      if (!Arrays.asList(maskedRssArray).contains(new StringT(level2resource.getName()))) {
+        if (level2resource.getName().contains("TriggerAdapter") || level2resource.getName().contains("FanoutTTCciTA")) {
+          logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a TA.");
+          hasAtriggerAdapter=true;
+          if (level2resource.getName().contains("DummyTriggerAdapter")) {
+            logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a DummyTriggerAdapter.");
+            hasAdummy=true;
+          }
         }
-      }
-      if (level2resource.getName().contains("hcalTrivialFU")) {
-        logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a FU.");
-        hasAnFU=true;
-      }
-      if (level2resource.getName().contains("hcalEventBuilder")) {
-        logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has an eventBuilder.");
-        hasAnEventBuilder=true;
+        if (level2resource.getName().contains("hcalTrivialFU")) {
+          logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a FU.");
+          hasAnFU=true;
+        }
+        if (level2resource.getName().contains("hcalEventBuilder")) {
+          logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has an eventBuilder.");
+          hasAnEventBuilder=true;
+        }
       }
     }
     Map<String, Boolean> response = new HashMap<String, Boolean>();

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import rcms.util.logger.RCMSLogger;
 import rcms.common.db.DBConnectorException;
@@ -42,6 +43,7 @@ public class HCALMasker {
     boolean hasAnEventBuilder = false;
     boolean hasAnFU = false;
     VectorT<StringT> maskedRss =  (VectorT<StringT>)functionManager.getHCALparameterSet().get("MASKED_RESOURCES").getValue();
+    logger.warn(maskedRss.toString());
     StringT[] maskedRssArray = maskedRss.toArray(new StringT[maskedRss.size()]);
 
     for (Resource level2resource : level2Children) {
@@ -174,8 +176,8 @@ public class HCALMasker {
 
     logger.info("[Martin log "+ functionManager.FMname + "]: The list of MaskedFMs from gui is " + MaskedFMs.toString());
     String userXmlMaskedFM = "not set";
+    String localrunkey = ((StringT)functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue()).getString();
     try{
-        String localrunkey = ((StringT)functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue()).getString();
         userXmlMaskedFM = xmlHandler.getNamedUserXMLelementAttributeValue("RunConfig", localrunkey, "maskedFM");
         logger.info("[Martin log " + functionManager.FMname + "]: Got the following maskedFM from userXML: "+ userXmlMaskedFM );
     } catch (UserActionException e){
@@ -196,6 +198,18 @@ public class HCALMasker {
 
     //Update the MaskedResources for pickEvmTrig
     VectorT<StringT> allMaskedResources = new VectorT<StringT>();
+    String userXmlMaskedApps= "not set";
+    try{
+        userXmlMaskedApps = xmlHandler.getNamedUserXMLelementAttributeValue("RunConfig", localrunkey, "maskedapps");
+    } catch (UserActionException e){
+    }
+    if (!userXmlMaskedApps.equals("")) {
+      String[] userXmlMaskedAppsArray = userXmlMaskedApps.split((Pattern.quote("|")));
+      for (String xmlMaskedApp : userXmlMaskedAppsArray) {
+        MaskedFMs.add(new StringT(xmlMaskedApp));
+      }
+    }
+
     try {
       allMaskedResources = MaskedFMs.clone();
     }


### PR DESCRIPTION
Fixes a bug in masking EvmTrig apps. Prior to this, masked EvmTrig apps would be accepted as "candidates" for their EvmTrig duties, which would break scenarios when EvmTrigApps were masked individually, as opposed to being masked as part of a function manager mask. This should enable app-by-app masking for TA's/EventBuilders/FUs.