### PR TITLE
Support for cold-init

### DIFF
--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -551,7 +551,7 @@ public class HCALFunctionManager extends UserFunctionManager {
         sv.registerConditionState(containerFMChildren,HCALStates.CONFIGURING);
         sv.registerConditionState(containerlpmController,HCALStates.CONFIGURING);
         if (asynchcalSupervisor) {
-          sv.registerConditionState(containerhcalSupervisor,Arrays.asList(HCALStates.PREINIT,HCALStates.INIT));
+          sv.registerConditionState(containerhcalSupervisor,Arrays.asList(HCALStates.PREINIT,HCALStates.COLDINIT,HCALStates.INIT));
         }
         svCalc.add(sv);
       }

--- a/src/rcms/fm/app/level1/HCALStates.java
+++ b/src/rcms/fm/app/level1/HCALStates.java
@@ -28,6 +28,8 @@ public final class HCALStates {
 
 	public static final State PREINIT = new State("Pre-Init");
 
+	public static final State COLDINIT = new State("Cold-Init");
+
 	public static final State INIT = new State("Init");
 
 	public static final State CONFIGURED = new State("Configured");


### PR DESCRIPTION
References #187 
- Add Cold-Init state
- Use in state calculation (supervisor: Cold-Init --> FM: Configuring)
- Level-1 transition timeout is always set to maximum value (which is the cold init timeout value of 20 minutes)
- For Level-2's, the default transition timeout is 4 minutes, unless the supervisor goes to Cold-Init, in which case the timeout extends to 20 minutes
