### PR TITLE
Configuration Progress

### DIFF
--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -78,15 +78,14 @@ $(document).ready(function () {
     });
 });
 
-function setProgress(progress) {
-    var currentState = $('#currentState').text();
+function setProgress(parName, progress) {
     var numberOfEvents = $("#NUMBER_OF_EVENTS").val();
     var width = $(".container").width();
     var progressPercent = 0;
-    if (currentState == "Running") {
+    if (parName == "HCAL_EVENTSTAKEN") {
       progressPercent = 100 * progress / numberOfEvents;
     }
-    else {
+    else if ( parName == "PROGRESS") {
       progressPercent = 100 * progress;
     }
     var progressBarWidth = progressPercent * (width / 100);

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -79,9 +79,16 @@ $(document).ready(function () {
 });
 
 function setProgress(progress) {
+    var currentState = $('#currentState').text();
     var numberOfEvents = $("#NUMBER_OF_EVENTS").val();
     var width = $(".container").width();
-    var progressPercent = 100 * progress / numberOfEvents;
+    var progressPercent = 0;
+    if (currentState == "Running") {
+      progressPercent = 100 * progress / numberOfEvents;
+    }
+    else {
+      progressPercent = 100 * progress;
+    }
     var progressBarWidth = progressPercent * (width / 100);
     //$(".progressbar").width(progressBarWidth);
     progressPercent = progressPercent.toFixed(2);

--- a/gui/js/notifications.js
+++ b/gui/js/notifications.js
@@ -17,7 +17,7 @@ function myUpdateParameters(message) {
                     pValue = pValueNode.textContent;
                     //if (pName == "SUPERVISOR_ERROR") { showsupervisorerror(pValue); }
                     //if (pName == "NUMBER_OF_EVENTS") { getfullpath(pValue); }
-                    if (pName == "HCAL_EVENTSTAKEN") { setProgress(pValue); }
+                    if (pName == "HCAL_EVENTSTAKEN" || pName == "PROGRESS") { setProgress(pValue); }
                 }
             }
         }

--- a/gui/js/notifications.js
+++ b/gui/js/notifications.js
@@ -17,7 +17,7 @@ function myUpdateParameters(message) {
                     pValue = pValueNode.textContent;
                     //if (pName == "SUPERVISOR_ERROR") { showsupervisorerror(pValue); }
                     //if (pName == "NUMBER_OF_EVENTS") { getfullpath(pValue); }
-                    if (pName == "HCAL_EVENTSTAKEN" || pName == "PROGRESS") { setProgress(pValue); }
+                    if (pName == "HCAL_EVENTSTAKEN" || pName == "PROGRESS") { setProgress(pName, pValue); }
                 }
             }
         }

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2437,10 +2437,18 @@ public class HCALEventHandler extends UserEventHandler {
 
                   status = pam.getValue("PartitionState");
                   stateName = pam.getValue("stateName");
+                  progress = pam.getValue("InitializationProgress");
 
                   if (status==null || stateName==null) {
                     String errMessage = "[HCAL " + functionManager.FMname + "] Error! Asking the hcalSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
                     functionManager.goToError(errMessage);
+                  }
+                  if (progress == null) {
+                    // TODO: do something more drastic in this case?
+                    logger.error("[JohnLogProgress] " + functionManager.FMname + " Something went wrong when asking the hcalSupervisor for her InitializationProgress...");
+                  }
+                  else {
+                    functionManager.getHCALparameterSet().put(new FunctionManagerParameter<DoubleT>("PROGRESS", new DoubleT(progress)));
                   }
 
                   logger.debug("[HCAL " + functionManager.FMname + "] asking for the HCAL supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2432,12 +2432,12 @@ public class HCALEventHandler extends UserEventHandler {
               for (QualifiedResource qr : functionManager.containerhcalSupervisor.getApplications() ){
                 try {
                   pam =((XdaqApplication)qr).getXDAQParameter();
-                  pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress", "stateName"});
+                  pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress", "overallProgress",, "stateName"});
                   pam.get();
 
                   status = pam.getValue("PartitionState");
                   stateName = pam.getValue("stateName");
-                  progress = pam.getValue("InitializationProgress");
+                  progress = pam.getValue("overallProgress");
 
                   if (status==null || stateName==null) {
                     String errMessage = "[HCAL " + functionManager.FMname + "] Error! Asking the hcalSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
@@ -2445,7 +2445,7 @@ public class HCALEventHandler extends UserEventHandler {
                   }
                   if (progress == null) {
                     // TODO: do something more drastic in this case?
-                    logger.error("[JohnLogProgress] " + functionManager.FMname + " Something went wrong when asking the hcalSupervisor for her InitializationProgress...");
+                    logger.error("[JohnLogProgress] " + functionManager.FMname + " Something went wrong when asking the hcalSupervisor for her overallProgress...");
                   }
                   else {
                     functionManager.getHCALparameterSet().put(new FunctionManagerParameter<DoubleT>("PROGRESS", new DoubleT(progress)));

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -17,6 +17,7 @@ import java.net.URISyntaxException;
 import java.util.Random;
 import java.net.URL;
 import java.net.MalformedURLException;
+import java.lang.Math;
 
 import java.io.StringWriter;
 import java.io.PrintWriter;
@@ -2304,14 +2305,21 @@ public class HCALEventHandler extends UserEventHandler {
         }
 
         // move the little fishys every 2s
-        if (functionManager.FMrole.equals("HCAL") && icount%2==0) {
-          // move the little fishy when configuring
+        if ( icount%2==0) {
+          // tell little fishy in HCAL and HF to say configuration progress when configuring
           if ((functionManager != null) && (functionManager.isDestroyed() == false) && (functionManager.getState().getStateString().equals(HCALStates.CONFIGURING.toString()))) {
-            LittleA.movehim();
+            Double progress = ((DoubleT)functionManager.getHCALparameterSet().get("PROGRESS").getValue()).getDouble()*100;
+            Double RoundedProgress = Math.round(progress * 100.0) / 100.0 ;
+            if( RoundedProgress > 0.0){
+              String msg = "___><)))\'>: Configuration progress = "+ RoundedProgress +" %_________________________________________";
+              functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT(msg)));
+            }
           }
-          // move the little fishy when running
-          if ((functionManager != null) && (functionManager.isDestroyed() == false) && functionManager.getState().getStateString().equals(HCALStates.RUNNING.toString()) ) {
-            LittleB.movehim();
+          // move the little fishy in HCAL when running
+          if(functionManager.FMrole.equals("HCAL")){
+            if ((functionManager != null) && (functionManager.isDestroyed() == false) && functionManager.getState().getStateString().equals(HCALStates.RUNNING.toString()) ) {
+              LittleB.movehim();
+            }
           }
         }
 

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2432,7 +2432,7 @@ public class HCALEventHandler extends UserEventHandler {
               for (QualifiedResource qr : functionManager.containerhcalSupervisor.getApplications() ){
                 try {
                   pam =((XdaqApplication)qr).getXDAQParameter();
-                  pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress", "overallProgress",, "stateName"});
+                  pam.select(new String[] {"TriggerAdapterName", "PartitionState", "InitializationProgress", "overallProgress", "stateName"});
                   pam.get();
 
                   status = pam.getValue("PartitionState");

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -24,7 +24,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 	static RCMSLogger logger = new RCMSLogger(HCALFunctionManager.class);
 
 	private static HCALParameters instance;
-  private static final String guiParams[] = new String[] {"HCAL_EVENTSTAKEN", "NUMBER_OF_EVENTS", "ACTION_MSG", "SUPERVISOR_ERROR", "RUN_NUMBER", "CONFIGURED_WITH_RUN_NUMBER", "STARTED_WITH_RUN_NUMBER"};
+  private static final String guiParams[] = new String[] {"HCAL_EVENTSTAKEN", "NUMBER_OF_EVENTS", "ACTION_MSG", "SUPERVISOR_ERROR", "RUN_NUMBER", "CONFIGURED_WITH_RUN_NUMBER", "STARTED_WITH_RUN_NUMBER", "PROGRESS"};
 
 	private HCALParameters() {
 		super();
@@ -45,6 +45,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 		this.put( new FunctionManagerParameter<IntegerT> ("HCAL_EVENTSTAKEN"                 ,  new IntegerT(-1)       ,  FunctionManagerParameter.Exported.READONLY) );  // Events taken. Really the number of triggers the TA claims to have issued
 
 		this.put( new FunctionManagerParameter<DoubleT>  ("COMPLETION"                       ,  new DoubleT(-1)        ,  FunctionManagerParameter.Exported.READONLY) );  // Completion meter
+		this.put( new FunctionManagerParameter<DoubleT>  ("PROGRESS"                         ,  new DoubleT(-1)        ,  FunctionManagerParameter.Exported.READONLY) );  // Completion meter
 
 		this.put( new FunctionManagerParameter<StringT>  ("FED_ENABLE_MASK"                  ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // FED enable mask, typically handed to us by the level0
 		this.put( new FunctionManagerParameter<StringT>  ("STATE"                            ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // State the Function Manager is currently in

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -1500,9 +1500,9 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       while ( stopProgressThread == false && functionManager.isDestroyed() == false ) {
 
         Iterator it = functionManager.containerFMChildren.getQualifiedResourceList().iterator();
+        progress = 0.0;
         while (it.hasNext()) {
           FunctionManager childFM = (FunctionManager) it.next();
-          progress = 0.0;
           if (childFM.isInitialized()) {
             ParameterSet<FunctionManagerParameter> lvl2pars;
             try {

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -13,6 +13,7 @@ import rcms.fm.fw.parameter.CommandParameter;
 import rcms.fm.fw.parameter.FunctionManagerParameter;
 import rcms.fm.fw.parameter.ParameterSet;
 import rcms.fm.fw.parameter.type.IntegerT;
+import rcms.fm.fw.parameter.type.DoubleT;
 import rcms.fm.fw.parameter.type.StringT;
 import rcms.fm.fw.parameter.type.BooleanT;
 import rcms.fm.fw.parameter.type.VectorT;
@@ -393,6 +394,11 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       if (!functionManager.containerTTCciControl.isEmpty()) {
         TTCciWatchThread ttcciwatchthread = new TTCciWatchThread(functionManager);
         ttcciwatchthread.start();
+      }
+
+      if (functionManager.containerhcalSupervisor.isEmpty()) {
+       // TODO: handle this case appropriately for FMs with no hcalSupervisor
+       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<DoubleT>("PROGRESS",new DoubleT(1.0)));
       }
      
       String CfgCVSBasePath           = "not set";


### PR DESCRIPTION
Adds a new parameter "PROGRESS" to the levelOne and levelTwo FunctionManagers:
- In the level2s, PROGRESS is simply equal to that of the controlled hcalSupervisor's overallProgress infospace parameter, and if no hcalSupervisor is controlled, the progress is set to 1
- In the level1, PROGRESS is the average of the level2s' PROGRESSes. 

The PROGRESS parameter is employed in the level1 (and level2s') GUI to fill the same progress bar that is used to track the number of events taken. PROGRESS however should be useful for global as well as local running.

A follow-up request is to add the numerical value of the progress into the ACTION_MESSAGE in front of the fishy. Martin has agreed to do that -- we could choose to merge this branch either before or after the ACTION_MESSAGE gets this change.