### PR TITLE
Simpler xml parsing

### DIFF
--- a/PortSnippet.py
+++ b/PortSnippet.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import re
+
+def PortSnippet(input_path, output_path):
+	# Define regexes for more complicated remappings
+	re_FMSettings = re.compile("<FMSettings")
+	re_RunInfoPublish = re.compile("RunInfoPublish=\"(?P<RunInfoPublish>true|false)\"")
+	re_OfficialRunNumbers = re.compile("OfficialRunNumbers=\"(?P<OfficialRunNumbers>true|false)\"")
+	re_NumberOfEvents = re.compile("NumberOfEvents=\"(?P<NumberOfEvents>\d+)\"")
+
+	re_include = re.compile("<include")
+	re_include_file = re.compile("file=\"/(?P<file>.+?)\"")
+	re_include_version = re.compile("version=\"(?P<version>.+?)\"")
+
+	# Define a simple map for string.replaces
+	tag_mapping = {
+		"CfgScript":"HCAL_CFGSCRIPT",
+		"PIControl":"HCAL_PICONTROL",
+		"TCDSControl":"HCAL_TCDSCONTROL",
+		"LPMControl":"HCAL_LPMCONTROL",
+		"FedEnableMask":"FED_ENABLE_MASK",
+		"AlarmerURL":"HCAL_ALARMER_URL",
+	}
+
+	input_snippet = open(input_path, 'r')
+	output_snippet_text = ""
+	for line in input_snippet:
+		# FMSettings
+		if re_FMSettings.search(line):
+			match_RunInfoPublish = re_RunInfoPublish.search(line)
+			if match_RunInfoPublish:
+				output_snippet_text += "<HCAL_RUNINFOPUBLISH>{}</HCAL_RUNINFOPUBLISH>\n".format(match_RunInfoPublish.group("RunInfoPublish"))
+
+			match_OfficialRunNumbers = re_OfficialRunNumbers.search(line)
+			if match_OfficialRunNumbers:
+				output_snippet_text += "<OFFICIAL_RUN_NUMBERS>{}</OFFICIAL_RUN_NUMBERS>\n".format(match_OfficialRunNumbers.group("OfficialRunNumbers"))
+
+			match_NumberOfEvents = re_NumberOfEvents.search(line)
+			if match_NumberOfEvents:
+				output_snippet_text += "<NUMBER_OF_EVENTS>{}</NUMBER_OF_EVENTS>\n".format(match_NumberOfEvents.group("OfficialRunNumbers"))
+
+		# xi:includes
+		elif re_include.search(line):
+			match_include_file = re_include_file.search(line)
+			if not match_include_file:
+				raise ParsingError("Didn't find file in include line {}".format(line))
+			include_file = match_include_file.group("file").replace("^/", "")
+			match_include_version = re_include_version.search(line)
+			if not match_include_version:
+				raise ParsingError("Didn't find version in include line {}".format(line))
+			include_version = match_include_version.group("version")
+			output_snippet_text += "<xi:include parse=\"text\" href=\"{}/{}\"/>\n".format(include_file, include_version)
+
+		# Tag replacements/nothing to change
+		else:
+			for input_tag, output_tag in tag_mapping.iteritems():
+				line = line.replace(input_tag, output_tag)
+			output_snippet_text += line
+	input_snippet.close()
+
+	output_snippet = open(output_path, 'w')
+	output_snippet.write(output_snippet_text)
+	output_snippet.close()
+
+class ParsingError(Exception):
+   def __init__(self, arg):
+      self.args = arg
+
+
+if __name__ == "__main__":
+	import argparse
+	parser = argparse.ArgumentParser(description="Convert snippets to FM parameter-centric format")
+	parser.add_argument("input_path", type=str, help="Input snippet path")
+	parser.add_argument("output_path", type=str, help="Output snippet path")
+	args = parser.parse_args()
+
+	try:
+		PortSnippet(args.input_path, args.output_path)
+	except ParsingError,e:
+		import time
+		print "Failed to parse snippet:"
+		print "".join(e.args)
+		sys.exit(1)
+
+	#os.system("diff {} {}".format(args.input_path, args.output_path))
+	os.system("cat {}".format(args.output_path))

--- a/example_snippet.xml
+++ b/example_snippet.xml
@@ -1,0 +1,71 @@
+<mastersnippet>
+<CommonMasterSnippet file="Master/common_led.xml"/>
+<HCAL_RUNINFOPUBLISH>true</HCAL_RUNINFOPUBLISH>
+<OFFICIAL_RUN_NUMBERS>true</OFFICIAL_RUN_NUMBERS>
+<HCAL_CFGSCRIPT>
+  include(/Common/Global.cfg:pro)
+  include(/Common/Connectivity.cfg:pro)
+
+  include(/DCC/Settings-GlobalRun.cfg:pro)
+  include(/DCC/Firmware.cfg:pro)
+
+  include(/HTR/Settings-GlobalRun.cfg:pro)
+  include(/HTR/Firmware.cfg:pro)
+
+  include(/TTCfanout/HcalSlave.cfg:pro)
+  include(/TTCfanout/HcalMaster.cfg:pro)
+  include(/TTCfanout/RCTMaster.cfg:pro)
+
+  include(/HLX/Settings.cfg:pro)
+  include(/SLB/Settings.cfg:pro)
+
+  include(/Trigger/Pedestal.cfg:pro)
+  include(/Trigger/Laser-OrbitGap.cfg:pro)
+  
+  include(/Laser/uMNioQIE.cfg:pro)
+  include(/Laser/uMNioOrbitGap.cfg:pro)
+  include(/Laser/uMNioQIE-GlobalRun.cfg:pro)
+  
+  include(/RBX/Settings-GlobalRun.cfg:pro)
+  include(/RBX/RBXlists.cfg:pro) 
+  include(/RBX/Tags_oracle.cfg:pro)
+  include(/RBX/RBXstatus.cfg:pro)   
+
+  include(/TechTrigProc/Firmware.cfg:pro)
+  include(/TechTrigProc/Settings-HO.cfg:pro)
+  include(/TechTrigProc/Settings-HF.cfg:pro)
+  include(/TechTrigProc/Settings-HBHE.cfg:pro)
+
+  include(/Other/TSManager.cfg:pro)
+  include(/Other/HcalWriter.cfg:pro)
+
+  include(/HTR/LUTs.cfg:pro)
+  include(/HTR/ZeroSuppression.cfg:pro)  
+  #include(/HTR/SpecialZeroSuppression.cfg:pro)
+ 
+  include(/Lumi/Settings.cfg:pro)
+  include(/Lumi/Settings-GlobalRun.cfg:pro)
+
+  include(/TechTrigProc/Settings-HO-coinc-timeDiff.cfg:pro)
+
+  include(/uTCA/Global.cfg:pro)
+  include(/uTCA/uHTR.cfg:pro)
+  include(/uTCA/uHTR-GlobalRun.cfg:pro)
+  include(/uTCA/DTC.cfg:pro)
+  include(/uTCA/DTC-CDAQ.cfg:pro)
+
+</HCAL_CFGSCRIPT>
+
+<HCAL_PICONTROL></HCAL_PICONTROL>
+<HCAL_TCDSCONTROL>
+<xi:include parse="text" href=TCDS/BGo_global.cfg/pro/>
+<xi:include parse="text" href=TCDS/global.cfg/pro/>
+<xi:include parse="text" href=TCDS/BGo_CalibSequence.cfg/pro/>
+</HCAL_TCDSCONTROL>
+
+<FED_ENABLE_MASK>700&amp;3%701&amp;3%702&amp;3%703&amp;3%704&amp;3%705&amp;3%706&amp;3%707&amp;3%708&amp;3%709&amp;3%710&amp;3%711&amp;3%712&amp;3%713&amp;3%714&amp;3%715&amp;3%716&amp;3%1100&amp;3%1102&amp;3%1104&amp;3%1106&amp;3%1108&amp;3%1110&amp;3%1112&amp;3%1114&amp;3%1116&amp;3%717&amp;3%720&amp;3%721&amp;3%1118&amp;3%1120&amp;3%1122&amp;3%724&amp;3%725&amp;3%726&amp;3%727&amp;3%728&amp;3%729&amp;3%730&amp;3%731&amp;3%</FED_ENABLE_MASK>
+
+
+<HCAL_ALARMER_URL>http://hcalmon.cms:9945</HCAL_ALARMER_URL>
+
+</mastersnippet>

--- a/installation/build.xml
+++ b/installation/build.xml
@@ -33,6 +33,12 @@
 		<pathelement location="${rcms.classes}"/>
 	</path>
 
+	<path id="ext.classpath">
+		<fileset dir="../ext/">
+			<include name="gson-2.8.0.jar"/>
+		</fileset>
+	</path>
+
 	<!-- Compiles this StateMachine -->
 	<target name="compile" depends="clean">
 		<echo message="Compile this FunctionManager code" />
@@ -44,8 +50,11 @@
 			srcdir="${fm.src}"
 			destdir="${fm.classes}"
 			failonerror="true"
-      nowarn="true">
-			<classpath refid="rcms.classpath"/>
+      		nowarn="true">
+			<classpath>
+				<path refid="ext.classpath"/>
+				<path refid="rcms.classpath"/>
+			</classpath>
 			<compilerarg value="-Xlint"/>
 	    </javac>
 	</target>

--- a/installation/build.xml
+++ b/installation/build.xml
@@ -33,11 +33,13 @@
 		<pathelement location="${rcms.classes}"/>
 	</path>
 
+	<!--
 	<path id="ext.classpath">
 		<fileset dir="../ext/">
 			<include name="gson-2.8.0.jar"/>
 		</fileset>
 	</path>
+	-->
 
 	<!-- Compiles this StateMachine -->
 	<target name="compile" depends="clean">
@@ -52,7 +54,7 @@
 			failonerror="true"
       		nowarn="true">
 			<classpath>
-				<path refid="ext.classpath"/>
+				<!--<path refid="ext.classpath"/>-->
 				<path refid="rcms.classpath"/>
 			</classpath>
 			<compilerarg value="-Xlint"/>

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2603,11 +2603,11 @@ public class HCALEventHandler extends UserEventHandler {
     public void run() {
       stopAlarmerWatchThread = false;
       try {
-        URL alarmerURL = new URL(functionManager.alarmerURL);
+        URL alarmerURL = new URL(((StringT)functionManager.getHCALparameterSet().get("HCAL_ALARMER_URL").getValue()).getString());
       } catch (MalformedURLException e) {
         // in case the URL is bogus, just don't run the thread
         stopAlarmerWatchThread = true;
-        logger.warn("[HCAL " + functionManager.FMname + "] HCALEventHandler: alarmerWatchThread: value of alarmerURL is not valid: " + functionManager.alarmerURL + "; not checking alarmer status");
+        logger.warn("[HCAL " + functionManager.FMname + "] HCALEventHandler: alarmerWatchThread: value of alarmerURL is not valid: " + ((StringT)functionManager.getHCALparameterSet().get("HCAL_ALARMER_URL").getValue() .getString())+ "; not checking alarmer status");
       }
 
       // poll alarmer status in the Running/RunningDegraded states every 30 sec to see if it is still OK/alive
@@ -2619,7 +2619,7 @@ public class HCALEventHandler extends UserEventHandler {
           try {
             // ask for the status of the HCAL alarmer
             // ("http://hcalmon.cms:9945","hcalAlarmer",0);
-            XDAQParameter pam = new XDAQParameter(functionManager.alarmerURL,"hcalAlarmer",0);
+            XDAQParameter pam = new XDAQParameter(((StringT)functionManager.getHCALparameterSet().get("HCAL_ALARMER_URL").getValue(),.getString())"hcalAlarmer",0);
             // this does a lazy get. do we need to force the update before getting it?
             //logger.info("[SethLog] HCALEventHandler: alarmerWatchThread: value of alarmer parameter GlobalStatus is " + pam.getValue("GlobalStatus"));
             String alarmerStatusValue = "";

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2663,7 +2663,7 @@ public class HCALEventHandler extends UserEventHandler {
       } catch (MalformedURLException e) {
         // in case the URL is bogus, just don't run the thread
         stopAlarmerWatchThread = true;
-        logger.warn("[HCAL " + functionManager.FMname + "] HCALEventHandler: alarmerWatchThread: value of alarmerURL is not valid: " + ((StringT)functionManager.getHCALparameterSet().get("HCAL_ALARMER_URL").getValue() .getString())+ "; not checking alarmer status");
+        logger.warn("[HCAL " + functionManager.FMname + "] HCALEventHandler: alarmerWatchThread: value of alarmerURL is not valid: " + ((StringT)functionManager.getHCALparameterSet().get("HCAL_ALARMER_URL").getValue()).getString() + "; not checking alarmer status");
       }
 
       // poll alarmer status in the Running/RunningDegraded states every 30 sec to see if it is still OK/alive
@@ -2705,7 +2705,7 @@ public class HCALEventHandler extends UserEventHandler {
 
             // ask for the status of the HCAL alarmer
             // ("http://hcalmon.cms:9945","hcalAlarmer",0);
-            XDAQParameter pam = new XDAQParameter(((StringT)functionManager.getHCALparameterSet().get("HCAL_ALARMER_URL").getValue(),.getString())"hcalAlarmer",0);
+            XDAQParameter pam = new XDAQParameter(((StringT)functionManager.getHCALparameterSet().get("HCAL_ALARMER_URL").getValue()).getString(), "hcalAlarmer", 0);
             // this does a lazy get. do we need to force the update before getting it?
 
             // Get the status for each watched alarm

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -217,8 +217,6 @@ public class HCALFunctionManager extends UserFunctionManager {
 
   public String rcmsStateListenerURL = "";
 
-  public String alarmerURL = "";
-
   public String alarmerPartition = "";
 
   public HCALFunctionManager() {

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -11,6 +11,7 @@ import rcms.fm.fw.parameter.type.IntegerT;
 import rcms.fm.fw.parameter.type.BooleanT;
 import rcms.fm.fw.parameter.type.StringT;
 import rcms.fm.fw.parameter.type.VectorT;
+import rcms.fm.fw.parameter.type.MapT;
 
 import rcms.util.logger.RCMSLogger;
 
@@ -97,6 +98,11 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 		this.put( new FunctionManagerParameter<VectorT<StringT>> ("MASKED_RESOURCES"         ,  new VectorT<StringT>()    ) );  // List of masked resources
 		this.put( new FunctionManagerParameter<VectorT<StringT>> ("MASK_SUMMARY"             ,  new VectorT<StringT>()    ) );  // Summary of masked FMs for user understandability
 		this.put( new FunctionManagerParameter<VectorT<StringT>> ("EMPTY_FMS"                ,  new VectorT<StringT>()    ) );  // LV2 FMs without XDAQs
+
+		//this.put( new FunctionManagerParameter<VectorT<StringT>> ("TEST_VECTORT_STRINGT", new VectorT<StringT>()));
+		//this.put( new FunctionManagerParameter<VectorT<IntegerT>> ("TEST_VECTORT_INTEGERT", new VectorT<IntegerT>()));
+		//this.put( new FunctionManagerParameter<MapT<StringT>> ("TEST_MAPT_STRINGT", new MapT<StringT>()));
+		//this.put( new FunctionManagerParameter<MapT<IntegerT>> ("TEST_MAPT_INTEGERT", new MapT<IntegerT>()));
 	}
 
 	public static HCALParameters getInstance() {

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -118,11 +118,11 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 
 	public synchronized HCALParameters getClonedParameterSet() { 
     HCALParameters cloned = new HCALParameters();
-		for (Map.Entry<String, FunctionManagerParameter> pair : this.getMap().entrySet()) {
-			if (pair.getValue() instanceof FunctionManagerParameter) {
-				cloned.put(new FunctionManagerParameter((FunctionManagerParameter) pair.getValue()));
-			}
+	for (Map.Entry<String, FunctionManagerParameter> pair : this.getMap().entrySet()) {
+		if (pair.getValue() instanceof FunctionManagerParameter) {
+			cloned.put(new FunctionManagerParameter((FunctionManagerParameter) pair.getValue()));
 		}
+	}
 	  return cloned;
 	}
 

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -68,6 +68,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 		this.put( new FunctionManagerParameter<StringT>  ("CONFIGURED_WITH_RUN_KEY"          ,  new StringT("not set") ,  FunctionManagerParameter.Exported.READONLY) );  // Configuration information for l0: Global configuration key at last configure
 		this.put( new FunctionManagerParameter<StringT>  ("CONFIGURED_WITH_TPG_KEY"          ,  new StringT("not set") ,  FunctionManagerParameter.Exported.READONLY) );  // Configuration information for l0: Trigger key at last configure
 		this.put( new FunctionManagerParameter<StringT>  ("CONFIGURED_WITH_FED_ENABLE_MASK"  ,  new StringT("not set") ,  FunctionManagerParameter.Exported.READONLY) );  // Configuration information for l0:  FED enable mask at last configure
+		this.put( new FunctionManagerParameter<StringT>  ("HCAL_ALARMER_URL"                 ,  new StringT("not set") ,  FunctionManagerParameter.Exported.READONLY) );  // Configuration information for l0:  FED enable mask at last configure
 
 		this.put( new FunctionManagerParameter<BooleanT> ("USE_PRIMARY_TCDS"                 ,  new BooleanT(true)     ,  FunctionManagerParameter.Exported.READONLY) );  // Switch for using the secondary TCDS system
 		this.put( new FunctionManagerParameter<BooleanT> ("HCAL_RUNINFOPUBLISH"              ,  new BooleanT(false)    ,  FunctionManagerParameter.Exported.READONLY) );  // Switch for publishing RunInfo 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -628,26 +628,10 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       String selectedRun = ((StringT)functionManager.getHCALparameterSet().get("RUN_CONFIG_SELECTED").getValue()).getString();
       String CfgCVSBasePath = ((StringT)functionManager.getParameterSet().get("HCAL_CFGCVSBASEPATH").getValue()).getString();
 
-      // Try to find a common masterSnippet from MasterSnippet
-      String CommonMasterSnippetFile ="";
-      try{
-        String TagName="CommonMasterSnippet";
-        String attribute="file";
-        CommonMasterSnippetFile = xmlHandler.getHCALMasterSnippetTagAttribute(selectedRun,CfgCVSBasePath,TagName,attribute);
-      }
-      catch(UserActionException e){
-        logger.error("[HCAL LVL1"+functionManager.FMname+"]: Found more than one CommonMasterSnippet tag in the mastersnippet! This is not allowed!");
-        functionManager.goToError(e.getMessage());
-      }
 
       //Check if the NUMBER_OF_EVENTS parameter is already set from GUI, if so, ignore settings from mastersnippet
       boolean NeventIsSetFromGUI = !xmlHandler.hasDefaultValue("NUMBER_OF_EVENTS",1000);
 
-      if(!CommonMasterSnippetFile.equals("")){    
-          //parse and set HCAL parameters from CommonMasterSnippet
-          logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet : "+ CommonMasterSnippetFile);
-          xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath,NeventIsSetFromGUI);
-      }
       //Parse and set HCAL parameters from MasterSnippet
       logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
       xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath,NeventIsSetFromGUI);

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -686,7 +686,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final PIControlSequence   is like this: \n"  +FullPIControlSequence               );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final TTCciControlSequence is like this: \n" +FullTTCciControlSequence            );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final LTCControlSequence is like this: \n"   +FullLTCControlSequence              );
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final AlarmerURL is "                        +functionManager.alarmerURL          );
+      //logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final AlarmerURL is "                        +functionManager.alarmerURL          );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final AlarmerPartition is "                  +functionManager.alarmerPartition    );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The FED_ENABLE_MASK used by the level-1 is: "    +FedEnableMask                       );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The RunInfoPublish value is : "                  +RunInfoPublish                      );

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -606,9 +606,9 @@ public class HCALxmlHandler {
       }
 
       // Print test parameters
-      if (functionManager.getHCALparameterSet().contains("TEST_VECTORT_STRINGT")) {
-        logger.info("[HCAL " + functionManager.FMname + "] Printing test parameter TEST_VECTORT_STRINGT: " + functionManager.getHCALparameterSet().get("TEST_VECTORT_STRINGT").getValue());
-      }
+      //if (functionManager.getHCALparameterSet().contains("TEST_VECTORT_STRINGT")) {
+      //  logger.info("[HCAL " + functionManager.FMname + "] Printing test parameter TEST_VECTORT_STRINGT: " + functionManager.getHCALparameterSet().get("TEST_VECTORT_STRINGT").getValue());
+      //}
       //if (functionManager.getHCALparameterSet().contains("TEST_VECTORT_INTEGERT")) {
       //  logger.info("[HCAL " + functionManager.FMname + "] Printing test parameter TEST_VECTORT_INTEGERT: " + //functionManager.getHCALparameterSet().get("TEST_VECTORT_INTEGERT").getValue());
       //}

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -501,17 +501,6 @@ public class HCALxmlHandler {
         
           logger.info("[HCAL " + functionManager.FMname + "]: Parsing parameter " + parameterName + ", type=" + parameterType + ", value=" + parameterValue);
 
-          // Overwrite/concatenate flag
-          Boolean concatenate = false;
-          if (parameterElement.hasAttribute("conflict")) {
-            if (!parameterType.equals("StringT")) {
-              logger.warn("[HCAL " + functionManager.FMname + "]: attribute 'conflict' (=overwrite or concatenate) is only implemented for StringT parameters. This parameter will be overwritten.");
-              concatenate = false;
-            } else {
-              concatenate = (parameterElement.getAttributes().getNamedItem("conflict").getNodeValue().equals("concatenate"));
-            }
-          }
-
           switch (parameterType) {
             case "BooleanT":
             {
@@ -555,21 +544,16 @@ public class HCALxmlHandler {
             }
             case "StringT":
             {
-              if (concatenate) {
-                logger.info("[HCAL " + functionManager.FMname + "]: Hold on to your butts, I am about to CONCATENATE a PARAMETER!");
+              if (parameterName.equals("HCAL_CFGSCRIPT")) {
                 String oldString = ((StringT)functionManager.getHCALparameterSet().get(parameterName).getValue()).getString();
                 if (oldString.equals("not set")) {
                   oldString = "";
                 }
                 String newString = oldString + parameterValue;
-                logger.info("[HCAL " + functionManager.FMname + "]: Old = " + oldString);
-                logger.info("[HCAL " + functionManager.FMname + "]: New = " + newString);
-
                 functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(parameterName, new StringT(newString)));
               } else {
                 functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>(parameterName, new StringT(parameterValue)));
               }
-              break;
             }
             case "UnsignedIntegerT":
             {

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -553,14 +553,29 @@ public class HCALxmlHandler {
               break;
             }
             // VectorT and MapT parsing use JsonUtil from the rcms framework, as suggested by Hannes. 
-            // The type is inferred from the content: Number, String, Boolean, Array. 
+            // The type is inferred from the content: Double, Integer, String, Boolean. 
             case "VectorT":
             {
               Object parsedVector = JsonUtil.decode(parameterValue);
               //logger.info("[HCAL " + functionManager.FMname + "]: Result of parsing vector is " + parsedVector);
               if (parsedVector instanceof ArrayList<?>) {
-                VectorT tmpVectorT = new VectorT((ArrayList)parsedVector);
-                functionManager.getHCALparameterSet().put(new FunctionManagerParameter<VectorT<?>>(parameterName, tmpVectorT));
+                for (Object entry : (ArrayList)parsedVector) {
+                  if (entry instanceof Double) {
+                    ((VectorT)functionManager.getHCALparameterSet().get(parameterName).getValue()).add(new DoubleT((Double)entry));
+                  } else if (entry instanceof Integer) {
+                    ((VectorT)functionManager.getHCALparameterSet().get(parameterName).getValue()).add(new IntegerT((Integer)entry));
+                  } else if (entry instanceof Boolean) {
+                    ((VectorT)functionManager.getHCALparameterSet().get(parameterName).getValue()).add(new BooleanT((Boolean)entry));
+                  } else if (entry instanceof String) {
+                    ((VectorT)functionManager.getHCALparameterSet().get(parameterName).getValue()).add(new StringT((String)entry));
+                  } else {
+                    String errMessage = "[HCAL " + functionManager.FMname + "] parseMasterSnippet: Parameter " + parameterName + " was not parsed into a vector of Double, Integer, String, or Boolean.";
+                    throw new UserActionException(errMessage);
+                  }
+                }
+                // The following code unfortunately doesn't work: HCALParameters::run() starts throwing a `failed to update` error, somewhere in HCALParameters::getClonedParameterSet(). We suspect it's due to the wildcard ?, but don't understand why.
+                //VectorT tmpVectorT = new VectorT((ArrayList)parsedVector);
+                //functionManager.getHCALparameterSet().put(new FunctionManagerParameter<VectorT<? extends ParameterType>>(parameterName, tmpVectorT));
               } else {
                 String errMessage = "[HCAL " + functionManager.FMname + "] parseMasterSnippet: parsed vector failed instanceof ArrayList<?>. Parsed result = " + parsedVector;
                 throw new UserActionException(errMessage);
@@ -591,9 +606,9 @@ public class HCALxmlHandler {
       }
 
       // Print test parameters
-      //if (functionManager.getHCALparameterSet().contains("TEST_VECTORT_STRINGT")) {
-      //  logger.info("[HCAL " + functionManager.FMname + "] Printing test parameter TEST_VECTORT_STRINGT: " + //functionManager.getHCALparameterSet().get("TEST_VECTORT_STRINGT").getValue());
-      //}
+      if (functionManager.getHCALparameterSet().contains("TEST_VECTORT_STRINGT")) {
+        logger.info("[HCAL " + functionManager.FMname + "] Printing test parameter TEST_VECTORT_STRINGT: " + functionManager.getHCALparameterSet().get("TEST_VECTORT_STRINGT").getValue());
+      }
       //if (functionManager.getHCALparameterSet().contains("TEST_VECTORT_INTEGERT")) {
       //  logger.info("[HCAL " + functionManager.FMname + "] Printing test parameter TEST_VECTORT_INTEGERT: " + //functionManager.getHCALparameterSet().get("TEST_VECTORT_INTEGERT").getValue());
       //}


### PR DESCRIPTION
Working version of new master snippet parser enforcing XML tag <=> FM parameter (https://github.com/HCALRunControl/levelOneHCALFM/issues/170). Replaces the previous include method (which used HCALxmlHandler::readFile()) with XInclude. Also adds support for specifying VectorT, and MapT parameters in JSON format, which are parsed with the rcms JsonUtil (for example, [1,2,3] or {"key1":"value1","key2":"value2"}). 