### PR TITLE
Spectator mode and run taker identification

### DIFF
--- a/gui/css/common.css
+++ b/gui/css/common.css
@@ -85,6 +85,6 @@
 }
 .parameterInputField {
   font-family: "Open Sans",sans-serif;
-  font-size 100%;
+  font-size : 100%;
   width: 400px;
 }

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -51,12 +51,12 @@ function updatePage() {
     var cachedSupErr = $('#SUPERVISOR_ERROR').val();
     if ($('#currentState').text() == "Configured") {
       $('#Destroy').hide();
-      if ($('#commandSection :input[value="Halt+Destroy"]').size() == 0) {
+      if ($('input[value="Halt+Destroy"]').size() == 0) {
         $('#commandSection :input[value="Exit"]').val("Halt+Destroy");
         $('#commandSection :input[value="Halt+Destroy"]').insertAfter($('#Destroy'));
       }
       else {
-        $('#commandSection :input[value="Exit"]').remove();
+        $('input[value="Halt+Destroy"]').remove();
       }
     }
     var cachedState = $('#currentState').text();
@@ -77,8 +77,13 @@ function updatePage() {
         }
         if (currentState == "Configured") {
           $('#Destroy').hide();
-          $('#commandSection :input[value="Exit"]').val("Halt+Destroy");
-          $('#commandSection :input[value="Halt+Destroy"]').insertAfter($('#Destroy'));
+          if ($('input[value="Halt+Destroy"]').size() == 0) {
+            $('#commandSection :input[value="Exit"]').val("Halt+Destroy");
+            $('#commandSection :input[value="Halt+Destroy"]').insertAfter($('#Destroy'));
+          }
+        }
+        else {
+          $('input[value="Halt+Destroy"]').remove();
         }
         if (currentState == "Error") {
           $('#Destroy').show();
@@ -97,7 +102,7 @@ function updatePage() {
       cachedNevents = $('#NUMBER_OF_EVENTS').val();
       cachedSupErr = $('#SUPERVISOR_ERROR').val();
       cachedState = currentState;
-	    if ($('#EXIT').val() == "true" && currentState=="Halted") { onDestroyButton(); }
+	    if ($('#EXIT').val() == "true" && currentState=="Halted") { $('#Destroy').click(); }
       //$('#commandParameterCheckBox').attr("onclick", "onClickCommandParameterCheckBox(); toggle_visibility('Blork');");
     }, 750);
 
@@ -198,10 +203,15 @@ function fillMask() {
     $('#maskTest').html($('#MASKED_RESOURCES').val());
 }
 
-function makecheckboxes() {
+function getAvailableResources() {
     var param = $('#AVAILABLE_RESOURCES').html().replace("[", "").replace("]","");
     param =  param.replace(/['"]+/g, '');
     var array = param.split(',');
+    return array;
+}
+
+function makecheckboxes() {
+    array = getAvailableResources();
     var maskDivContents = "<strong>Partitions to mask:</strong>";
     maskDivContents += "<ul>";
     var radioButtonDivContents = "<strong>Partition to use:</strong><ul><form action=''>";
@@ -278,9 +288,35 @@ function moveversionnumber() {
       $("#elogInfo").text("Run # " + $("#RUN_NUMBER").val()  + " - " + $(".control_label2").first().text() + " - Local run key: "+ $("#CFGSNIPPET_KEY_SELECTED").val()  + " - " + $("#NUMBER_OF_EVENTS").val() + " events, masks: " + maskSummary);
     }
 
+function setupMaskingPanels() {
+    $('.maskModes').css("style", "display: inline");
+    $('.maskModes').click(function () {
+       $(this).siblings().css('color', 'black');
+       $(this).css('color', 'blue');
+       panelId = "#".concat($(this).attr("id")).concat("Selection");
+       $(panelId).siblings().hide();
+       $(panelId).show();
+       if ($(this).attr("id") == "multiPartition") {
+         if (!$('#newSINGLEPARTITION_MODEcheckbox :checkbox').prop('checked')) {
+           $('#newSINGLEPARTITION_MODEcheckbox :checkbox').click();
+         }
+         preclickFMs();
+         $('#SINGLEPARTITION_MODE').val("false");
+       }
+       else if ($(this).attr("id") == "singlePartition") {
+         if (!$('#newSINGLEPARTITION_MODEcheckbox :checkbox').prop('checked')) {
+           $('#newSINGLEPARTITION_MODEcheckbox :checkbox').click();
+         }
+         $('#SINGLEPARTITION_MODE').val("true");
+       }
+       //$(panelId).parent().find("input").prop('checked', false); // maybe this does something?
+       fillMask();
+    });
+}
 
 
 function hcalOnLoad() {
+  if ($('input[value="STATE"]').size() > 0) { // this is a sanity check to see if we're actually attached
     activate_relevant_table('AllParamTables');
     removeduplicatecheckbox('CFGSNIPPET_KEY_SELECTED');
     removeduplicatecheckbox('RUN_CONFIG_SELECTED');
@@ -325,28 +361,8 @@ function hcalOnLoad() {
     moveversionnumber();
     makedropdown($('#AVAILABLE_RUN_CONFIGS').text(), $('#AVAILABLE_LOCALRUNKEYS').text());
     onClickCommandParameterCheckBox();
-
-    $('.maskModes').css("style", "display: inline");
-    $('.maskModes').click(function () {
-       $(this).siblings().css('color', 'black');
-       $(this).css('color', 'blue');
-       panelId = "#".concat($(this).attr("id")).concat("Selection");
-       $(panelId).siblings().hide();
-       $(panelId).show();
-       if ($(this).attr("id") == "multiPartition") {
-         if (!$('#newSINGLEPARTITION_MODEcheckbox :checkbox').prop('checked')) {
-           $('#newSINGLEPARTITION_MODEcheckbox :checkbox').click();
-         }
-         preclickFMs();
-         $('#SINGLEPARTITION_MODE').val("false");
-       }
-       else if ($(this).attr("id") == "singlePartition") {
-         if (!$('#newSINGLEPARTITION_MODEcheckbox :checkbox').prop('checked')) {
-           $('#newSINGLEPARTITION_MODEcheckbox :checkbox').click();
-         }
-         $('#SINGLEPARTITION_MODE').val("true");
-       }
-       //$(panelId).parent().find("input").prop('checked', false); // maybe this does something?
-       fillMask();
-    });
+    setupMaskingPanels();
+    makecheckboxes();
+    updatePage();
+  }
 }

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -314,6 +314,30 @@ function setupMaskingPanels() {
     });
 }
 
+function spectatorMode(onOff) {
+  if (onOff) {
+    $('input').css("pointer-events: none;");
+    $('input').not("#FMPilotForm > input").attr("disabled", true);
+    $('#dropdown').css("pointer-events: none;");
+    $('#dropdown').attr("disabled", true);
+    var spectatorAllowed = ["Detach", "UpdatedRefresh", "showTreeButton", "showStatusTableButton", "refreshGlobalParametersButton", "globalParametersCheckbox", "drive"];
+    $.each(spectatorAllowed, function(index, id) {
+      $('#' + id).css("pointer events: default;");
+      $('#' + id).attr("disabled", false);
+    });
+    $("#spectate").hide();
+    $("#drive").show();
+  }
+  else {
+    $('input').css("pointer-events: default;");
+    $('input').not("input[type='text']").attr("disabled", false);
+    $('#dropdown').css("pointer-events: default;");
+    $('#dropdown').attr("disabled", false);
+    $('#spectate').show();
+    $('#drive').hide();
+  }
+}
+
 
 function hcalOnLoad() {
   if ($('input[value="STATE"]').size() > 0) { // this is a sanity check to see if we're actually attached

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -153,6 +153,7 @@ function clickboxes() {
         $('#newCFGSNIPPET_KEY_SELECTEDcheckbox :checkbox').click();
         $('#newRUN_CONFIG_SELECTEDcheckbox :checkbox').click();
         $('#newMASKED_RESOURCEScheckbox :checkbox').click();
+        $('#newDRIVER_IDENTIFIERcheckbox :checkbox').click();
     }
 }
 function preclickFMs() {
@@ -184,7 +185,7 @@ function makedropdown(availableRunConfigs, availableLocalRunKeys) {
     var masterSnippetArgs = "'" + masterSnippetNumber + "', 'RUN_CONFIG_SELECTED'";
     var maskedResourcesNumber = $('#MASKED_RESOURCES').attr("name").substring(20);
     var maskedResourcesArgs = "'" + maskedResourcesNumber + "', 'MASKED_RESOURCES'";
-    var onchanges = "onClickGlobalParameterCheckBox(" + cfgSnippetArgs + "); onClickGlobalParameterCheckBox(" + masterSnippetArgs + "); onClickGlobalParameterCheckBox(" + maskedResourcesArgs + "); clickboxes(); mirrorSelection(); preclickFMs(); fillMask();";
+    var onchanges = "onClickGlobalParameterCheckBox(" + cfgSnippetArgs + "); onClickGlobalParameterCheckBox(" + masterSnippetArgs + "); onClickGlobalParameterCheckBox(" + maskedResourcesArgs + "); clickboxes(); mirrorSelection(); preclickFMs(); fillMask(); fillDriverID();";
     $('#dropdown').attr("onchange", onchanges);
 }
 
@@ -338,6 +339,10 @@ function spectatorMode(onOff) {
   }
 }
 
+function fillDriverID() {
+  $('#DRIVER_IDENTIFIER').val($.fingerprint);
+}
+
 
 function hcalOnLoad() {
   if ($('input[value="STATE"]').size() > 0) { // this is a sanity check to see if we're actually attached
@@ -366,6 +371,8 @@ function hcalOnLoad() {
     copyContents(HCAL_TIME_OF_FM_START, newHCAL_TIME_OF_FM_START);
     copyContents(SINGLEPARTITION_MODE, newSINGLEPARTITION_MODE);
     makecheckbox('newSINGLEPARTITION_MODEcheckbox', 'SINGLEPARTITION_MODE');
+    copyContents(DRIVER_IDENTIFIER, newDRIVER_IDENTIFIER);
+    makecheckbox('newDRIVER_IDENTIFIERcheckbox', 'DRIVER_IDENTIFIER');
     hidecheckboxes();
     hideinitializebutton();
     hidelocalparams();

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -175,7 +175,9 @@ function makedropdown(availableRunConfigs, availableLocalRunKeys) {
     for (var i = 0; i<localRunKeysArray.length; i++) {
         maskedFM = "";
         if (runConfigMap[localRunKeysArray[i]].hasOwnProperty('maskedFM')) { maskedFM=runConfigMap[localRunKeysArray[i]].maskedFM; }
-        dropdownoption = dropdownoption + "<option value='" + runConfigMap[localRunKeysArray[i]].snippet + "' maskedresources='" + runConfigMap[localRunKeysArray[i]].maskedapps +"' maskedFM='" + maskedFM + "' >" + localRunKeysArray[i] + "</option>";
+        singlePartitionFM = "";
+        if (runConfigMap[localRunKeysArray[i]].hasOwnProperty('singlePartitionFM')) { singlePartitionFM=runConfigMap[localRunKeysArray[i]].singlePartitionFM; }
+        dropdownoption = dropdownoption + "<option value='" + runConfigMap[localRunKeysArray[i]].snippet + "' maskedresources='" + runConfigMap[localRunKeysArray[i]].maskedapps +"' maskedFM='" + maskedFM + "' + singlePartitionFM='" + singlePartitionFM + "' >" + localRunKeysArray[i] + "</option>";
     }
     dropdownoption = dropdownoption + "</select>";
     $('#dropdowndiv').html(dropdownoption);
@@ -185,7 +187,7 @@ function makedropdown(availableRunConfigs, availableLocalRunKeys) {
     var masterSnippetArgs = "'" + masterSnippetNumber + "', 'RUN_CONFIG_SELECTED'";
     var maskedResourcesNumber = $('#MASKED_RESOURCES').attr("name").substring(20);
     var maskedResourcesArgs = "'" + maskedResourcesNumber + "', 'MASKED_RESOURCES'";
-    var onchanges = "onClickGlobalParameterCheckBox(" + cfgSnippetArgs + "); onClickGlobalParameterCheckBox(" + masterSnippetArgs + "); onClickGlobalParameterCheckBox(" + maskedResourcesArgs + "); clickboxes(); mirrorSelection(); preclickFMs(); fillMask(); fillDriverID();";
+    var onchanges = "onClickGlobalParameterCheckBox(" + cfgSnippetArgs + "); onClickGlobalParameterCheckBox(" + masterSnippetArgs + "); onClickGlobalParameterCheckBox(" + maskedResourcesArgs + "); clickboxes(); mirrorSelection(); preclickFMs(); fillMask(); automateSinglePartition(); fillDriverID();";
     $('#dropdown').attr("onchange", onchanges);
 }
 
@@ -198,17 +200,23 @@ function fillMask() {
     //$('#dropdown option:selected').text()
     var userXMLmaskedApps = $('#dropdown option:selected').attr("maskedresources").split("|");
     for (var i = 0; i < userXMLmaskedApps.length; i++) {
-      finalMasks.push(userXMLmaskedApps[i]);
+      if (userXMLmaskedApps[i] != "") finalMasks.push(userXMLmaskedApps[i]);
     }
     $('#MASKED_RESOURCES').val(JSON.stringify(finalMasks));
-    $('#maskTest').html($('#MASKED_RESOURCES').val());
+    var masksToShow = "[";
+    var availableResources = getAvailableResources();
+    $.each(finalMasks, function(index, maskedResource) {
+      if ( $.inArray(maskedResource, availableResources) > -1){
+        masksToShow += maskedResource + ", ";
+      }
+    });
+    masksToShow += "]";
+    masksToShow = masksToShow.replace(", ]", "]");
+    $('#maskTest').text(masksToShow);
 }
 
 function getAvailableResources() {
-    var param = $('#AVAILABLE_RESOURCES').html().replace("[", "").replace("]","");
-    param =  param.replace(/['"]+/g, '');
-    var array = param.split(',');
-    return array;
+    return JSON.parse($('#AVAILABLE_RESOURCES').val());
 }
 
 function makecheckboxes() {
@@ -232,6 +240,7 @@ function makecheckboxes() {
 function picksinglepartition(option) {
     $('#multiPartitionSelection :input').not("[value='"+option+"']").prop('checked', true);
     $("#multiPartitionSelection :input[value='"+option+"']").prop('checked', false);
+    $('#setGlobalParametersButton').show();
     fillMask();
 }
 
@@ -303,12 +312,16 @@ function setupMaskingPanels() {
          }
          preclickFMs();
          $('#SINGLEPARTITION_MODE').val("false");
+         $('#singlePartitionSelection :input').prop('checked', false);
+         $('#setGlobalParametersButton').show();
        }
        else if ($(this).attr("id") == "singlePartition") {
          if (!$('#newSINGLEPARTITION_MODEcheckbox :checkbox').prop('checked')) {
            $('#newSINGLEPARTITION_MODEcheckbox :checkbox').click();
          }
          $('#SINGLEPARTITION_MODE').val("true");
+       	 $('#singlePartitionSelection :input').prop('checked', false);
+         $('#setGlobalParametersButton').hide();
        }
        //$(panelId).parent().find("input").prop('checked', false); // maybe this does something?
        fillMask();
@@ -351,6 +364,23 @@ function takeOverDriving() {
 }
 
 
+function automateSinglePartition() {
+  var singlePartitionFM = $('#dropdown option:selected').attr("singlePartitionFM");
+  if (singlePartitionFM != "") {
+    if ($.inArray(singlePartitionFM, getAvailableResources()) > -1) {
+      $('#singlePartition').click();   
+      var selector = '#singlePartitionSelection :input[value="' + singlePartitionFM + '"]';
+      $(selector).click();
+    }
+    else {
+      alert("Error! It seems that the singlePartitionFM specified by the run key does not match with any FM name! The requested singlePartitionFM is: " + defaultPartition);
+    }
+  }
+  else {
+    $('#multiPartition').click();   
+    $('#setGlobalParametersButton').show();
+  }
+}
 
 function hcalOnLoad() {
   if ($('input[value="STATE"]').size() > 0) { // this is a sanity check to see if we're actually attached

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -102,7 +102,7 @@ function updatePage() {
       cachedNevents = $('#NUMBER_OF_EVENTS').val();
       cachedSupErr = $('#SUPERVISOR_ERROR').val();
       cachedState = currentState;
-	    if ($('#EXIT').val() == "true" && currentState=="Halted") { $('#Destroy').click(); }
+	    if ($('#EXIT').val() == "true" && currentState=="Halted" && $.fingerprint() == $('#DRIVER_IDENTIFIER').val()) { $('#Destroy').click(); }
       //$('#commandParameterCheckBox').attr("onclick", "onClickCommandParameterCheckBox(); toggle_visibility('Blork');");
     }, 750);
 
@@ -321,7 +321,7 @@ function spectatorMode(onOff) {
     $('input').not("#FMPilotForm > input").attr("disabled", true);
     $('#dropdown').css("pointer-events: none;");
     $('#dropdown').attr("disabled", true);
-    var spectatorAllowed = ["Detach", "UpdatedRefresh", "showTreeButton", "showStatusTableButton", "refreshGlobalParametersButton", "globalParametersCheckbox", "drive"];
+    var spectatorAllowed = ["Detach", "UpdatedRefresh", "showTreeButton", "showStatusTableButton", "refreshGlobalParametersButton", "globalParametersCheckbox", "showFullMasks", "drive"];
     $.each(spectatorAllowed, function(index, id) {
       $('#' + id).css("pointer events: default;");
       $('#' + id).attr("disabled", false);
@@ -336,12 +336,20 @@ function spectatorMode(onOff) {
     $('#dropdown').attr("disabled", false);
     $('#spectate').show();
     $('#drive').hide();
+    if ( !($('#DRIVER_IDENTIFIER').val() == "not set" ||  $.fingerprint() == $('#DRIVER_IDENTIFIER').val())) $('#takeOver').show();
   }
 }
 
 function fillDriverID() {
-  $('#DRIVER_IDENTIFIER').val($.fingerprint);
+  $('#DRIVER_IDENTIFIER').val($.fingerprint());
 }
+
+function takeOverDriving() {
+  $('#newDRIVER_IDENTIFIERcheckbox :checkbox').click();
+  fillDriverID()
+  $('#setGlobalParametersButton').click();
+}
+
 
 
 function hcalOnLoad() {
@@ -395,5 +403,17 @@ function hcalOnLoad() {
     setupMaskingPanels();
     makecheckboxes();
     updatePage();
+    if ($('#DRIVER_IDENTIFIER').val() != "not set") {
+      if ($.fingerprint() != $('#DRIVER_IDENTIFIER').val()) {
+        $('#spectate').click(); 
+	      console.log("did not match fingerprint to driver identifier. fingerprint: " + $.fingerprint() + " ,  driver identifier: " + $('#DRIVER_IDENTIFIER').val());
+      }
+      else if ($.fingerprint() == $('#DRIVER_IDENTIFIER').val()) $('#drive').click();
+      else console.log("Could not determine whether the browser session is one that was or was not driving the run.");
+    }
+    else {
+      $('#drive').hide();
+      $('#spectate').hide();
+    }
   }
 }

--- a/gui/js/jquery.browser-fingerprint-1.1.js
+++ b/gui/js/jquery.browser-fingerprint-1.1.js
@@ -1,0 +1,79 @@
+// Browser fingerprinting is a technique to "mark" anonymous users using JS
+// (or other things).  To build an "identity" of sorts the browser is queried
+// for a list of its plugins, the screen size and several other things, then
+// hashes them.  The idea is that these bits of information produce an unique
+// "fingerprint" of sorts; the more elaborate the list of data points is, the
+// more unique this fingerprint becomes.  And you wouldn't even need to set a
+// cookie to recognize this user when she visits again.
+//
+// For more information on this topic consult
+// [Ars Technica](http://arstechnica.com/tech-policy/news/2010/05/how-your-web-browser-rats-you-out-online.ars)
+// or the [EFF](http://panopticlick.eff.org/).  There is a lot of potential
+// for undesirable shenanigans, and I strictly oppose using this technique for
+// marketing and ad-related tracking purposes.
+//
+// Anyways, I needed a really simple fingerprinting library, so I wrote a
+// quick and dirty jQuery plugin.  This is by no means a complete and
+// watertight implementation -- it is merely the scratch for a particular itch
+// I was having.  YMMV.
+//
+// This library was written by Carlo Zottmann, carlo@municode.de, has its home
+// on [Github](http://github.com/carlo/jquery-browser-fingerprint) and is
+// WTF-licensed (see LICENSE.txt).
+
+( function($) {
+
+  // Calling `jQuery.fingerprint()` will return an MD5 hash, i.e. said
+  // fingerprint.
+
+  $.fingerprint = function() {
+
+    // This function, `_raw()`, uses several browser details which are
+    // available to JS here to build a string, namely...
+    //
+    // * the user agent
+    // * screen size
+    // * color depth
+    // * the timezone offset
+    // * sessionStorage support
+    // * localStorage support
+    // * the list of all installed plugins (we're using their names,
+    //    descriptions, mime types and file name extensions here)
+    function _raw() {
+      // That string is the return value.
+      return [
+        navigator.userAgent,
+        [ screen.height, screen.width, screen.colorDepth ].join("x"),
+        ( new Date() ).getTimezoneOffset(),
+        !!window.sessionStorage,
+        !!window.localStorage,
+        $.map( navigator.plugins, function(p) {
+          return [
+            p.name,
+            p.description,
+            $.map( p, function(mt) {
+              return [ mt.type, mt.suffixes ].join("~");
+            }).join(",")
+          ].join("::");
+        }).join(";")
+      ].join("###");
+    }
+
+    // `_md5()` computes a MD5 hash using [md5-js](http://github.com/wbond/md5-js/).
+    function _md5() {
+      if ( typeof window.md5 === "function" ) {
+        // The return value is the hashed fingerprint string.
+        return md5( _raw() );
+      }
+      else {
+        // If `window.md5()` isn't available, an error is thrown.
+        throw "md5 unavailable, please get it from http://github.com/wbond/md5-js/";
+      }
+    }
+
+    // And, since I'm lazy, calling `$.fingerprint()` will return the hash
+    // right away, without the need for any other calls.
+    return _md5();
+  }
+
+})(jQuery);

--- a/gui/js/md5.js
+++ b/gui/js/md5.js
@@ -1,0 +1,180 @@
+/*!
+ * Joseph Myer's md5() algorithm wrapped in a self-invoked function to prevent
+ * global namespace polution, modified to hash unicode characters as UTF-8.
+ *  
+ * Copyright 1999-2010, Joseph Myers, Paul Johnston, Greg Holt, Will Bond <will@wbond.net>
+ * http://www.myersdaily.org/joseph/javascript/md5-text.html
+ * http://pajhome.org.uk/crypt/md5
+ * 
+ * Released under the BSD license
+ * http://www.opensource.org/licenses/bsd-license
+ */
+(function() {
+	function md5cycle(x, k) {
+		var a = x[0], b = x[1], c = x[2], d = x[3];
+
+		a = ff(a, b, c, d, k[0], 7, -680876936);
+		d = ff(d, a, b, c, k[1], 12, -389564586);
+		c = ff(c, d, a, b, k[2], 17, 606105819);
+		b = ff(b, c, d, a, k[3], 22, -1044525330);
+		a = ff(a, b, c, d, k[4], 7, -176418897);
+		d = ff(d, a, b, c, k[5], 12, 1200080426);
+		c = ff(c, d, a, b, k[6], 17, -1473231341);
+		b = ff(b, c, d, a, k[7], 22, -45705983);
+		a = ff(a, b, c, d, k[8], 7, 1770035416);
+		d = ff(d, a, b, c, k[9], 12, -1958414417);
+		c = ff(c, d, a, b, k[10], 17, -42063);
+		b = ff(b, c, d, a, k[11], 22, -1990404162);
+		a = ff(a, b, c, d, k[12], 7, 1804603682);
+		d = ff(d, a, b, c, k[13], 12, -40341101);
+		c = ff(c, d, a, b, k[14], 17, -1502002290);
+		b = ff(b, c, d, a, k[15], 22, 1236535329);
+
+		a = gg(a, b, c, d, k[1], 5, -165796510);
+		d = gg(d, a, b, c, k[6], 9, -1069501632);
+		c = gg(c, d, a, b, k[11], 14, 643717713);
+		b = gg(b, c, d, a, k[0], 20, -373897302);
+		a = gg(a, b, c, d, k[5], 5, -701558691);
+		d = gg(d, a, b, c, k[10], 9, 38016083);
+		c = gg(c, d, a, b, k[15], 14, -660478335);
+		b = gg(b, c, d, a, k[4], 20, -405537848);
+		a = gg(a, b, c, d, k[9], 5, 568446438);
+		d = gg(d, a, b, c, k[14], 9, -1019803690);
+		c = gg(c, d, a, b, k[3], 14, -187363961);
+		b = gg(b, c, d, a, k[8], 20, 1163531501);
+		a = gg(a, b, c, d, k[13], 5, -1444681467);
+		d = gg(d, a, b, c, k[2], 9, -51403784);
+		c = gg(c, d, a, b, k[7], 14, 1735328473);
+		b = gg(b, c, d, a, k[12], 20, -1926607734);
+
+		a = hh(a, b, c, d, k[5], 4, -378558);
+		d = hh(d, a, b, c, k[8], 11, -2022574463);
+		c = hh(c, d, a, b, k[11], 16, 1839030562);
+		b = hh(b, c, d, a, k[14], 23, -35309556);
+		a = hh(a, b, c, d, k[1], 4, -1530992060);
+		d = hh(d, a, b, c, k[4], 11, 1272893353);
+		c = hh(c, d, a, b, k[7], 16, -155497632);
+		b = hh(b, c, d, a, k[10], 23, -1094730640);
+		a = hh(a, b, c, d, k[13], 4, 681279174);
+		d = hh(d, a, b, c, k[0], 11, -358537222);
+		c = hh(c, d, a, b, k[3], 16, -722521979);
+		b = hh(b, c, d, a, k[6], 23, 76029189);
+		a = hh(a, b, c, d, k[9], 4, -640364487);
+		d = hh(d, a, b, c, k[12], 11, -421815835);
+		c = hh(c, d, a, b, k[15], 16, 530742520);
+		b = hh(b, c, d, a, k[2], 23, -995338651);
+
+		a = ii(a, b, c, d, k[0], 6, -198630844);
+		d = ii(d, a, b, c, k[7], 10, 1126891415);
+		c = ii(c, d, a, b, k[14], 15, -1416354905);
+		b = ii(b, c, d, a, k[5], 21, -57434055);
+		a = ii(a, b, c, d, k[12], 6, 1700485571);
+		d = ii(d, a, b, c, k[3], 10, -1894986606);
+		c = ii(c, d, a, b, k[10], 15, -1051523);
+		b = ii(b, c, d, a, k[1], 21, -2054922799);
+		a = ii(a, b, c, d, k[8], 6, 1873313359);
+		d = ii(d, a, b, c, k[15], 10, -30611744);
+		c = ii(c, d, a, b, k[6], 15, -1560198380);
+		b = ii(b, c, d, a, k[13], 21, 1309151649);
+		a = ii(a, b, c, d, k[4], 6, -145523070);
+		d = ii(d, a, b, c, k[11], 10, -1120210379);
+		c = ii(c, d, a, b, k[2], 15, 718787259);
+		b = ii(b, c, d, a, k[9], 21, -343485551);
+
+		x[0] = add32(a, x[0]);
+		x[1] = add32(b, x[1]);
+		x[2] = add32(c, x[2]);
+		x[3] = add32(d, x[3]);
+	}
+
+	function cmn(q, a, b, x, s, t) {
+		a = add32(add32(a, q), add32(x, t));
+		return add32((a << s) | (a >>> (32 - s)), b);
+	}
+
+	function ff(a, b, c, d, x, s, t) {
+		return cmn((b & c) | ((~b) & d), a, b, x, s, t);
+	}
+
+	function gg(a, b, c, d, x, s, t) {
+		return cmn((b & d) | (c & (~d)), a, b, x, s, t);
+	}
+
+	function hh(a, b, c, d, x, s, t) {
+		return cmn(b ^ c ^ d, a, b, x, s, t);
+	}
+
+	function ii(a, b, c, d, x, s, t) {
+		return cmn(c ^ (b | (~d)), a, b, x, s, t);
+	}
+
+	function md51(s) {
+		// Converts the string to UTF-8 "bytes" when necessary
+		if (/[\x80-\xFF]/.test(s)) {
+			s = unescape(encodeURI(s));
+		}
+		txt = '';
+		var n = s.length, state = [1732584193, -271733879, -1732584194, 271733878], i;
+		for (i = 64; i <= s.length; i += 64) {
+			md5cycle(state, md5blk(s.substring(i - 64, i)));
+		}
+		s = s.substring(i - 64);
+		var tail = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+		for (i = 0; i < s.length; i++)
+		tail[i >> 2] |= s.charCodeAt(i) << ((i % 4) << 3);
+		tail[i >> 2] |= 0x80 << ((i % 4) << 3);
+		if (i > 55) {
+			md5cycle(state, tail);
+			for (i = 0; i < 16; i++) tail[i] = 0;
+		}
+		tail[14] = n * 8;
+		md5cycle(state, tail);
+		return state;
+	}
+
+	function md5blk(s) { /* I figured global was faster.   */
+		var md5blks = [], i; /* Andy King said do it this way. */
+		for (i = 0; i < 64; i += 4) {
+			md5blks[i >> 2] = s.charCodeAt(i) +
+			                  (s.charCodeAt(i + 1) << 8) +
+			                  (s.charCodeAt(i + 2) << 16) +
+			                  (s.charCodeAt(i + 3) << 24);
+		}
+		return md5blks;
+	}
+
+	var hex_chr = '0123456789abcdef'.split('');
+
+	function rhex(n) {
+		var s = '', j = 0;
+		for (; j < 4; j++)
+		s += hex_chr[(n >> (j * 8 + 4)) & 0x0F] +
+		     hex_chr[(n >> (j * 8)) & 0x0F];
+		return s;
+	}
+
+	function hex(x) {
+		for (var i = 0; i < x.length; i++)
+		x[i] = rhex(x[i]);
+		return x.join('');
+	}
+
+	md5 = function (s) {
+		return hex(md51(s));
+	}
+
+	/* this function is much faster, so if possible we use it. Some IEs are the
+	only ones I know of that need the idiotic second function, generated by an
+	if clause.  */
+	function add32(a, b) {
+		return (a + b) & 0xFFFFFFFF;
+	}
+
+	if (md5('hello') != '5d41402abc4b2a76b9719d911017c592') {
+		function add32(x, y) {
+			var lsw = (x & 0xFFFF) + (y & 0xFFFF),
+			    msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+			return (msw << 16) | (lsw & 0xFFFF);
+		}
+	}
+})();

--- a/gui/js/notifications.js
+++ b/gui/js/notifications.js
@@ -18,6 +18,7 @@ function myUpdateParameters(message) {
                     //if (pName == "SUPERVISOR_ERROR") { showsupervisorerror(pValue); }
                     //if (pName == "NUMBER_OF_EVENTS") { getfullpath(pValue); }
                     if (pName == "HCAL_EVENTSTAKEN" || pName == "PROGRESS") { setProgress(pName, pValue); }
+		    if (pName == "DRIVER_IDENTIFIER" && pValue != $.fingerprint()) { $('#spectate').click(); }
                 }
             }
         }

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -34,6 +34,8 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
   <rcms.control:customResourceRenderer indentation="1" type="css" path="/css/common.css" />
   <rcms.control:customResourceRenderer indentation="1" type="css" path="/css/hcalcontrol.css" />
   <rcms.control:customResourceRenderer indentation="1" type="js" path="/js/jquery.min.js" />
+  <rcms.control:customResourceRenderer indentation="1" type="js" path="/js/md5.js" />
+  <rcms.control:customResourceRenderer indentation="1" type="js" path="/js/jquery.browser-fingerprint-1.1.js" />
   <rcms.control:customResourceRenderer indentation="1" type="js" path="/js/hcalui.js" />
   <rcms.control:customResourceRenderer indentation="1" type="js" path="/js/GUI.js" />
   <rcms.control:customResourceRenderer indentation="1" type="js" path="/js/stateNotification.js" />
@@ -252,13 +254,22 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
                                 <td id ="newMASKED_RESOURCES" class="label_center_black">
                                 </td>
                               </tr>
-                              <tr id="singlePartitionField">
+                              <tr id="singlePartitionField" style="display: none;">
                                 <td id="newSINGLEPARTITION_MODEcheckbox" class="label_center_black">
                                 </td>
                                 <td class="label_left_black">
                                   <strong>Multi/Singlepartition</strong>
                                 </td>
                                 <td id ="newSINGLEPARTITION_MODE" class="label_center_black">
+                                </td>
+                              </tr>
+                              <tr id="driverIdField"> 
+                                <td id="newDRIVER_IDENTIFIERcheckbox" class="label_center_black">
+                                </td>
+                                <td class="label_left_black">
+                                  <strong>Driver Identifier</strong>
+                                </td>
+                                <td id ="newDRIVER_IDENTIFIER" class="label_center_black">
                                 </td>
                               </tr>
                               <tr>

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -366,7 +366,8 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
                           <!--Buttons for main table -->
                           <center>
                             <input id="spectate" class="button1" type="button" onclick="spectatorMode(true);" value="Spectate run">
-                            <input id="drive" class="button1" type="button" onclick="spectatorMode(false)" value="Control run">
+                            <input id="drive" class="button1" type="button" onclick="spectatorMode(false)" value="Enable control">
+                            <input id="takeOver" class="button1" type="button" onclick="takeOverDriving()" value="Take control" style="display: none">
                           </center>
 			  <br>
                           <center>

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -69,7 +69,7 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
 </head>
 
 
-
+<body style="display: none">
 <!-- Table T1 begin -->
 <table width="100%" border="0" cellpadding="0" cellspacing="0" style="position:absolute; top:0; background-color: #3a5165;">
 
@@ -441,8 +441,7 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
     $(document).ready(function() {
       onLoad();
       hcalOnLoad(); 
-      makecheckboxes();
-      updatePage();
+      $("body").show();
     });
   </script>
 </body>

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -354,6 +354,11 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
                           <br />
                           <!--Buttons for main table -->
                           <center>
+                            <input id="spectate" class="button1" type="button" onclick="spectatorMode(true);" value="Spectate run">
+                            <input id="drive" class="button1" type="button" onclick="spectatorMode(false)" value="Control run">
+                          </center>
+			  <br>
+                          <center>
                             <input id="setGlobalParametersButton" class="button1" type="button" onclick="onClickSetGlobalParameters()" value="Set Enabled Parameters" name="setGlobalParametersButton">
                             <input id="refreshGlobalParametersButton" class="button1" type="button" onclick="onClickRefreshGlobalParameter()" value="Refresh Parameters" name="refreshGlobalParametersButton">
                           </center>
@@ -364,7 +369,7 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
 
                       <tr>
                         <td align="center" class="label_center_black">
-                          <input type="checkbox" onclick="toggle_visibility('GlobalParamsTable');"> <strong>&nbsp; View Global Parameters</strong>
+                          <input id="globalParametersCheckbox" type="checkbox" onclick="toggle_visibility('GlobalParamsTable');"> <strong>&nbsp; View Global Parameters</strong>
                           <br /><br />
                           <table id="GlobalParamsTable" class="tbl">
                             <tr>

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -341,7 +341,7 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
                                     </div>
                                     <br />
                                     <div>
-                                      Masked resources: <span id="maskTest"></span>
+                                      Masked FMs: <span id="maskTest"></span>
                                       <div>
                                         <div id="multiPartitionSelection" class="tbl"></div>
                                         <div id="singlePartitionSelection" class="tbl"></div>

--- a/gui/jsp/footer.jspf
+++ b/gui/jsp/footer.jspf
@@ -4,7 +4,7 @@
   <td id="footer" align="left" valign="top">
     HCAL Online Software 
     <br>
-    CERN 2016
+    CERN 2017
     <br>
     <a href="mailto:cms-hcal-onlinesw@cern.ch ">
       cms-hcal-onlinesw@cern.ch 

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -737,7 +737,6 @@ public class HCALEventHandler extends UserEventHandler {
       String debugMessage = ("[HCAL " + functionManager.FMname + "] No FM childs found.\nThis is probably OK for a level 2 HCAL FM.\nThis FM has the role: " + functionManager.FMrole);
       logger.debug(debugMessage);
     }
-
     // see if we have any "special" FMs
     List<FunctionManager> evmTrigList = new ArrayList<FunctionManager>();
     List<FunctionManager> normalList = new ArrayList<FunctionManager>();

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2243,7 +2243,7 @@ public class HCALEventHandler extends UserEventHandler {
               XDAQParameter pam = null;
               String status   = "undefined";
               String stateName   = "undefined";
-              String progress = "undefined";
+              String progressFromSupervisor = "undefined";
               String taname   = "undefined";
 
               // ask for the status of the HCAL supervisor
@@ -2255,18 +2255,29 @@ public class HCALEventHandler extends UserEventHandler {
 
                   status = pam.getValue("PartitionState");
                   stateName = pam.getValue("stateName");
-                  progress = pam.getValue("overallProgress");
+                  progressFromSupervisor = pam.getValue("overallProgress");
 
                   if (status==null || stateName==null) {
                     String errMessage = "[HCAL " + functionManager.FMname + "] Error! Asking the hcalSupervisor for the PartitionState and stateName to see if it is alive or not resulted in a NULL pointer - this is bad!";
                     functionManager.goToError(errMessage);
                   }
-                  if (progress == null) {
+                  if (progressFromSupervisor == null) {
                     // TODO: do something more drastic in this case?
                     logger.error("[JohnLogProgress] " + functionManager.FMname + " Something went wrong when asking the hcalSupervisor for her overallProgress...");
                   }
                   else {
-                    functionManager.getHCALparameterSet().put(new FunctionManagerParameter<DoubleT>("PROGRESS", new DoubleT(progress)));
+		    logger.debug("JohnDebug: progressFromSupervisor " + qr.getName() + "in " + functionManager.FMname + " was " + progressFromSupervisor);
+                    try {
+		      if (!Double.isNaN(Double.parseDouble(progressFromSupervisor))) {
+                        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<DoubleT>("PROGRESS", new DoubleT(Double.parseDouble(progressFromSupervisor))));
+                      }
+		      else {
+		        logger.debug("JohnDebug: progressFromSupervisor was NaN. Not setting progress to NaN.");
+	              }
+                    }
+                    catch(NumberFormatException e) {
+		      logger.debug("JohnDebug: progressFromSupervisor was NOT parseable to a double. Will not set progress");
+                    }
                   }
 
                   logger.debug("[HCAL " + functionManager.FMname + "] asking for the HCAL supervisor PartitionState to see if it is still alive.\n The PartitionState is: " + status);

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -93,6 +93,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 		this.put( new FunctionManagerParameter<StringT>  ("LPM_SUPERVISOR"                   ,  new StringT("")           ) );  // Supervisor configuring the LPM
 		this.put( new FunctionManagerParameter<StringT>  ("EVM_TRIG_FM"                      ,  new StringT("")           ) );  // Function manager doing eventbuilding and triggeradapting duties
 		this.put( new FunctionManagerParameter<StringT>  ("FM_PARTITION"                     ,  new StringT("not set")    ) );  // TCDS partition of LV2 FM 
+		this.put( new FunctionManagerParameter<StringT>  ("DRIVER_IDENTIFIER"                ,  new StringT("not set")    ) );  // MD5 hash to identify browser session in charge 
 
 		this.put( new FunctionManagerParameter<BooleanT> ("CLOCK_CHANGED"                    ,  new BooleanT(false)       ) );  // Information from level0 on whether the clock source has changed
 		this.put( new FunctionManagerParameter<BooleanT> ("USE_RESET_FOR_RECOVER"            ,  new BooleanT(true)        ) );  // Switch for changing behavior of recover button

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -26,7 +26,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 	static RCMSLogger logger = new RCMSLogger(HCALFunctionManager.class);
 
 	private static HCALParameters instance;
-  private static final String guiParams[] = new String[] {"HCAL_EVENTSTAKEN", "NUMBER_OF_EVENTS", "ACTION_MSG", "SUPERVISOR_ERROR", "RUN_NUMBER", "CONFIGURED_WITH_RUN_NUMBER", "STARTED_WITH_RUN_NUMBER", "PROGRESS","EXIT"};
+  private static final String guiParams[] = new String[] {"HCAL_EVENTSTAKEN", "NUMBER_OF_EVENTS", "ACTION_MSG", "SUPERVISOR_ERROR", "RUN_NUMBER", "CONFIGURED_WITH_RUN_NUMBER", "STARTED_WITH_RUN_NUMBER", "PROGRESS","EXIT","DRIVER_IDENTIFIER"};
 
 	private HCALParameters() {
 		super();

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -1652,7 +1652,6 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
     public void run() {
       stopProgressThread = false;
       progress = 0.0;
-      logger.debug("[JohnLogProgress] " + functionManager.FMname + ": starting ProgressThread.");
       while ( stopProgressThread == false && functionManager.isDestroyed() == false && Math.abs(progress-1.0)>0.001) {
 
         Iterator it = functionManager.containerFMChildren.getQualifiedResourceList().iterator();
@@ -1669,7 +1668,6 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
               logger.warn("[HCAL " + functionManager.FMname + "] Could not update parameters for FM client: " + childFM.getResource().getName() + " The exception is:", e);
               return;
             }
-            logger.debug("Got progress from level2 FM" + childFM.getName() + " = " +((DoubleT)lvl2pars.get("PROGRESS").getValue()).getDouble());
             progress += ((DoubleT)lvl2pars.get("PROGRESS").getValue()).getDouble();
           }
         }
@@ -1679,7 +1677,10 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
 
         // delay between polls
         try { Thread.sleep(1000); }
-        catch (Exception ignored) { return; }
+        catch (Exception ignored) { 
+	  logger.warn("JohnDebug: Got an exception during progress thread polling. Exception message: " + ignored.getMessage());
+	  return;
+	}
       }
 
       // stop the Monitor watchdog thread

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -204,6 +204,10 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           if ( ((Element)nodes.item(i)).hasAttribute("maskedFM")){
             RunKeySetting.put(new StringT("maskedFM")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("maskedFM"  ).getNodeValue()));
           }
+          if ( ((Element)nodes.item(i)).hasAttribute("singlePartitionFM")){
+            RunKeySetting.put(new StringT("singlePartitionFM")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("singlePartitionFM").getNodeValue()));
+          }
+
           logger.debug("[HCAL " + functionManager.FMname + "]: RunkeySetting  is :"+ RunKeySetting.toString());
 
           LocalRunKeys.add(runkeyName);


### PR DESCRIPTION
This implements a browser fingerprinting method so that the FM can store who is currently driving the run, and the FM's stored parameter identifying the driver is used by the GUI to determine whether it is driving (and may take automated actions), or not -- in which case it enters a new "spectator mode" where buttons that send commands or set parameters are disabled.

I'd appreciate if you guys would test it out and see whether you like it. Right now it's only really handling local runs (though I don't think this change would do anything to global runs) but it could easily be modified to activate spectator mode during global runs.

This fixes the bug that happens when there is a spectator during Halt+Destroy, but I think it's also nice in other ways: it makes one feel safer when spectating on a run (you won't accidentally hit Destroy during e.g. an important sourcing run) and it helps to ensure only one person is driving at a time.