### PR TITLE
Show only FMs in mask preview

### DIFF
--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -200,14 +200,15 @@ function fillMask() {
       finalMasks.push(userXMLmaskedApps[i]);
     }
     $('#MASKED_RESOURCES').val(JSON.stringify(finalMasks));
-    var masksToShow = "";
+    var masksToShow = "[";
     var availableResources = getAvailableResources();
     $.each(finalMasks, function(index, maskedResource) {
       if ( $.inArray(maskedResource, availableResources) > -1){
         masksToShow += maskedResource + ", ";
       }
     });
-    masksToShow = masksToShow.slice(0, -2);
+    masksToShow += "]";
+    masksToShow = masksToShow.replace(", ]", "]");
     $('#maskTest').text(masksToShow);
 }
 

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -200,14 +200,19 @@ function fillMask() {
       finalMasks.push(userXMLmaskedApps[i]);
     }
     $('#MASKED_RESOURCES').val(JSON.stringify(finalMasks));
-    $('#maskTest').html($('#MASKED_RESOURCES').val());
+    var masksToShow = "";
+    var availableResources = getAvailableResources();
+    $.each(finalMasks, function(index, maskedResource) {
+      if ( $.inArray(maskedResource, availableResources) > -1){
+        masksToShow += maskedResource + ", ";
+      }
+    });
+    masksToShow = masksToShow.slice(0, -2);
+    $('#maskTest').text(masksToShow);
 }
 
 function getAvailableResources() {
-    var param = $('#AVAILABLE_RESOURCES').html().replace("[", "").replace("]","");
-    param =  param.replace(/['"]+/g, '');
-    var array = param.split(',');
-    return array;
+    return JSON.parse($('#AVAILABLE_RESOURCES').val());
 }
 
 function makecheckboxes() {

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -197,7 +197,7 @@ function fillMask() {
     //$('#dropdown option:selected').text()
     var userXMLmaskedApps = $('#dropdown option:selected').attr("maskedresources").split("|");
     for (var i = 0; i < userXMLmaskedApps.length; i++) {
-      finalMasks.push(userXMLmaskedApps[i]);
+      if (userXMLmaskedApps[i] != "") finalMasks.push(userXMLmaskedApps[i]);
     }
     $('#MASKED_RESOURCES').val(JSON.stringify(finalMasks));
     var masksToShow = "[";

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -330,7 +330,7 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
                                     </div>
                                     <br />
                                     <div>
-                                      Masked resources: <span id="maskTest"></span>
+                                      Masked FMs: <span id="maskTest"></span>
                                       <div>
                                         <div id="multiPartitionSelection" class="tbl"></div>
                                         <div id="singlePartitionSelection" class="tbl"></div>

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -380,7 +380,7 @@ public class HCALFunctionManager extends UserFunctionManager {
     if ( !getQualifiedGroup().seekQualifiedResourcesOfType(new FunctionManager()).isEmpty()) {
       int sessionId       = ((IntegerT)getParameterSet().get("SID").getValue()).getInteger();
       Integer SIDforLV0   = ((IntegerT)getParameterSet().get("INITIALIZED_WITH_SID").getValue()).getInteger();
-      if (logSessionConnector.getSession(sessionId)!=null){
+      if (logSessionConnector!=null && logSessionConnector.getSession(sessionId)!=null){
         LogSession currentSession = logSessionConnector.getSession(sessionId);
         logger.debug("[HCAL "+FMname+"] current log session is \n"+currentSession.toString());
         if (currentSession.isOpen()){


### PR DESCRIPTION
Implements the feature request of #244. Only FM names will be shown in the preview of masked resources visible during init time. Tested at 904.