### PR TITLE
Reduce mastersnippet parsing log output

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -379,7 +379,7 @@ public class HCALEventHandler extends UserEventHandler {
             else {
               pam.select(new String[] {"RunType", "ConfigurationDoc", "Partition", "RunSessionNumber", "hardwareConfigurationStringTCDS", "hardwareConfigurationStringLPM", "hardwareConfigurationStringPI", "fedEnableMask", "usePrimaryTCDS"});
               pam.setValue("RunType",functionManager.FMfullpath);
-              logger.info("[HCAL " + functionManager.FMname + "]: the ConfigurationDoc to be sent to the supervisor is: " + CfgScript);
+              logger.debug("[HCAL " + functionManager.FMname + "]: the ConfigurationDoc to be sent to the supervisor is: " + CfgScript);
               pam.setValue("ConfigurationDoc",CfgScript);
               pam.setValue("Partition",functionManager.FMpartition);
               pam.setValue("RunSessionNumber",Sid.toString());
@@ -2645,22 +2645,42 @@ public class HCALEventHandler extends UserEventHandler {
   
   // Function to receive parameter
   void CheckAndSetParameter(ParameterSet pSet , String PamName) throws UserActionException{
+    CheckAndSetParameter(pSet,PamName,true);
+  }
+
+  void CheckAndSetParameter(ParameterSet pSet , String PamName, boolean printResult) throws UserActionException{
+    String inputString = getUserFunctionManager().getLastInput().getInputString();
 
     if( pSet.get(PamName) != null){
       if (pSet.get(PamName).getType().equals(StringT.class)){
         String PamValue = ((StringT)pSet.get(PamName).getValue()).getString();
         functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(PamName, new StringT(PamValue)));
-        logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input. Here it is: \n"+ PamValue);
+        if(printResult){
+          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
+        }
+        else{
+          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString);
+        }
       }
       if (pSet.get(PamName).getType().equals(IntegerT.class)){
         Integer PamValue = ((IntegerT)pSet.get(PamName).getValue()).getInteger();
         functionManager.getParameterSet().put(new FunctionManagerParameter<IntegerT>(PamName, new IntegerT(PamValue)));
-        logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input. Here it is: \n"+ PamValue);
+        if(printResult){
+          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
+        }
+        else{
+          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString);
+        }
       }
       if (pSet.get(PamName).getType().equals(BooleanT.class)){
         Boolean PamValue = ((BooleanT)pSet.get(PamName).getValue()).getBoolean();
         functionManager.getParameterSet().put(new FunctionManagerParameter<BooleanT>(PamName, new BooleanT(PamValue)));
-        logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input. Here it is: \n"+ PamValue);
+        if(printResult){
+          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
+        }
+        else{
+          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString);
+        }
       }
     }
     else{

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2341,7 +2341,7 @@ public class HCALEventHandler extends UserEventHandler {
               if (!functionManager.containerTriggerAdapter.isEmpty()) {
                 {
                   String debugMessage = "[HCAL " + functionManager.FMname + "] TriggerAdapter found for asking its state - good!";
-                  logger.info(debugMessage);
+                  logger.debug(debugMessage);
                 }
                 XDAQParameter pam = null;
                 String status = "undefined";

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -49,19 +49,15 @@ public class HCALMasker {
     for (Resource level2resource : level2Children) {
       if (!Arrays.asList(maskedRssArray).contains(new StringT(level2resource.getName()))) {
         if (level2resource.getName().contains("TriggerAdapter") || level2resource.getName().contains("FanoutTTCciTA")) {
-          logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a TA.");
           hasAtriggerAdapter=true;
           if (level2resource.getName().contains("DummyTriggerAdapter")) {
-            logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a DummyTriggerAdapter.");
             hasAdummy=true;
           }
         }
         if (level2resource.getName().contains("hcalTrivialFU")) {
-          logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has a FU.");
           hasAnFU=true;
         }
         if (level2resource.getName().contains("hcalEventBuilder")) {
-          logger.info("[JohnLog2] " + functionManager.FMname + ": the FM being checked now has an eventBuilder.");
           hasAnEventBuilder=true;
         }
       }
@@ -130,18 +126,16 @@ public class HCALMasker {
           Group fullConfig = level2group.rs.retrieveLightGroup(level2.getResource());
           List<Resource> level2Children = fullConfig.getChildrenResources();
 
-          logger.warn("[JohnLog2] " + functionManager.FMname + ": the result of isEvmTrigCandidate()  on " + level2.getName() + " has isAcandidate: " + isEvmTrigCandidate(level2Children).get("isAcandidate").toString());
-          logger.warn("[JohnLog2] " + functionManager.FMname + ": the result of isEvmTrigCandidate() has isAdummyCandidate: " + isEvmTrigCandidate(level2Children).get("isAdummyCandidate").toString());
+          logger.debug("[JohnLog2] " + functionManager.FMname + ": the result of isEvmTrigCandidate()  on " + level2.getName() + " has isAcandidate: " + isEvmTrigCandidate(level2Children).get("isAcandidate").toString());
+          logger.debug("[JohnLog2] " + functionManager.FMname + ": the result of isEvmTrigCandidate() has isAdummyCandidate: " + isEvmTrigCandidate(level2Children).get("isAdummyCandidate").toString());
 
           try {
             if (!theresAcandidate && isEvmTrigCandidate(level2Children).get("isAcandidate")) {
-              logger.warn("[JohnLog2] found a non-dummy candidate.");
               candidates = getEvmTrigResources(level2Children);
               candidates.put("EvmTrigFM", level2.getResource());
               theresAcandidate = true;
             }
             if (!theresAdummyCandidate && isEvmTrigCandidate(level2Children).get("isAdummyCandidate")) {
-              logger.warn("[JohnLog2] found a dummy candidate.");
               candidates = getEvmTrigResources(level2Children);
               candidates.put("EvmTrigFM", level2.getResource());
               theresAcandidate = true;
@@ -149,7 +143,7 @@ public class HCALMasker {
             }
           }
           catch (UserActionException ex) {
-            logger.error("[JohnLog2] " + functionManager.FMname + ": got an exception while getting the EvmTrig resources for " + level2.getName() + ": " + ex.getMessage());
+            logger.error("[HCAL " + functionManager.FMname + " ]: got an exception while getting the EvmTrig resources for " + level2.getName() + ": " + ex.getMessage());
           }
         }
         catch (DBConnectorException ex) {
@@ -162,7 +156,7 @@ public class HCALMasker {
 
     for (Map.Entry<String, Resource> entry : candidates.entrySet()) {
       String key = entry.getKey();
-      logger.warn("[JohnLog2] key:" + key);
+      //logger.warn("[JohnLog2] key:" + key);
    }
   
   
@@ -223,7 +217,7 @@ public class HCALMasker {
               qr.setActive(false);
               StringT thisMaskedFM = new StringT(qr.getName());
               if (!Arrays.asList(maskedFMsVector.toArray()).contains(thisMaskedFM)) {
-                logger.info("[JohnLogMask] " + functionManager.FMname + ": about to add " + thisMaskedFM.getString() + " to the maskedFMsVector.");
+                logger.debug("[JohnLogMask] " + functionManager.FMname + ": about to add " + thisMaskedFM.getString() + " to the maskedFMsVector.");
                 maskedFMsVector.add(thisMaskedFM);
               }
 
@@ -236,7 +230,6 @@ public class HCALMasker {
               }
             }
           }
-          logger.info("[JohnLogMask] " + functionManager.FMname + ": about to set the global parameter MASK_SUMMARY");
         }
         for (Resource level2resource : fullconfigList) {
           if (level2resource.getName().contains("FanoutTTCciTA") || level2resource.getName().contains("TriggerAdapter") || level2resource.getName().contains("hcalTrivialFU") || level2resource.getName().contains("hcalEventBuilder")) {

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -776,7 +776,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       //Pring results from mastersnippet:
       logger.info("[HCAL LVL1 " + functionManager.FMname + "]  Printing results from parsing Mastersnippet(s): ");
       FullCfgScript = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGSCRIPT").getValue()).getString();
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The CfgScript from mastersnippet is like this: \n" + FullCfgScript);
+      logger.debug("[HCAL LVL1 " + functionManager.FMname + "] The CfgScript from mastersnippet is like this: \n" + FullCfgScript);
       if (TpgKey!=null && TpgKey!="NULL") {
 
         FullCfgScript += "\n### BEGIN TPG key add from HCAL FM named: " + functionManager.FMname + "\n";
@@ -794,7 +794,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           logger.error("[HCAL LVL1 " + functionManager.FMname + "] Error! For global runs we should have received a TPG_KEY.\nPlease check if HCAL is in the trigger.\n If HCAL is in the trigger and you see this message please call an expert - this is bad!!");
         }
       }
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final CfgScript is like this: \n" + FullCfgScript);
+      logger.debug("[HCAL LVL1 " + functionManager.FMname + "] The final CfgScript is like this: \n" + FullCfgScript);
 
       //Get the results from parseMasterSnippet      
       String TTCciControlSequence = ((StringT)functionManager.getHCALparameterSet().get("HCAL_TTCCICONTROL").getValue()).getString();
@@ -819,11 +819,11 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         PIControlSequence    = ((StringT)functionManager.getHCALparameterSet().get("HCAL_PICONTROL_MULTI"   ).getValue()).getString();
       }
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] ConfigureAction: We are in  Single Partition mode: " + isSinglePartition);
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final ICIControlSequence is like this: \n"   +ICIControlSequence              );
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final LPMControlSequence  is like this: \n"  +LPMControlSequence              );
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final PIControlSequence   is like this: \n"  +PIControlSequence               );
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final TTCciControlSequence is like this: \n" +TTCciControlSequence            );
-      logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final LTCControlSequence is like this: \n"   +LTCControlSequence              );
+      logger.debug("[HCAL LVL1 " + functionManager.FMname + "] The final ICIControlSequence is like this: \n"   +ICIControlSequence              );
+      logger.debug("[HCAL LVL1 " + functionManager.FMname + "] The final LPMControlSequence  is like this: \n"  +LPMControlSequence              );
+      logger.debug("[HCAL LVL1 " + functionManager.FMname + "] The final PIControlSequence   is like this: \n"  +PIControlSequence               );
+      logger.debug("[HCAL LVL1 " + functionManager.FMname + "] The final TTCciControlSequence is like this: \n" +TTCciControlSequence            );
+      logger.debug("[HCAL LVL1 " + functionManager.FMname + "] The final LTCControlSequence is like this: \n"   +LTCControlSequence              );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final AlarmerURL is "                        +functionManager.alarmerURL          );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The final AlarmerPartition is "                  +functionManager.alarmerPartition    );
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] The FED_ENABLE_MASK used by the level-1 is: "    +FedEnableMask                       );

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -531,20 +531,20 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           CheckAndSetParameter( parameterSet , "HCAL_RUNINFOPUBLISH" );
           CheckAndSetParameter( parameterSet , "OFFICIAL_RUN_NUMBERS");
           CheckAndSetParameter( parameterSet , "HCAL_CFGCVSBASEPATH" );
-          CheckAndSetParameter( parameterSet , "HCAL_CFGSCRIPT"      );
-          CheckAndSetParameter( parameterSet , "HCAL_TTCCICONTROL"   );
-          CheckAndSetParameter( parameterSet , "HCAL_LTCCONTROL"     );
+          CheckAndSetParameter( parameterSet , "HCAL_CFGSCRIPT"      ,false);
+          CheckAndSetParameter( parameterSet , "HCAL_TTCCICONTROL"   ,false);
+          CheckAndSetParameter( parameterSet , "HCAL_LTCCONTROL"     ,false);
           CheckAndSetParameter( parameterSet , "SINGLEPARTITION_MODE");
           isSinglePartition   = ((BooleanT)functionManager.getHCALparameterSet().get("SINGLEPARTITION_MODE").getValue()).getBoolean();
           // Only set the parameter being used so that RunInfo will be clear
           if(isSinglePartition){
-            CheckAndSetParameter( parameterSet , "HCAL_ICICONTROL_SINGLE"     );
-            CheckAndSetParameter( parameterSet , "HCAL_PICONTROL_SINGLE"      );
+            CheckAndSetParameter( parameterSet , "HCAL_ICICONTROL_SINGLE"     ,false);
+            CheckAndSetParameter( parameterSet , "HCAL_PICONTROL_SINGLE"      ,false);
           }
           else{
-            CheckAndSetParameter( parameterSet , "HCAL_LPMCONTROL"           );
-            CheckAndSetParameter( parameterSet , "HCAL_ICICONTROL_MULTI"     );
-            CheckAndSetParameter( parameterSet , "HCAL_PICONTROL_MULTI"      );
+            CheckAndSetParameter( parameterSet , "HCAL_LPMCONTROL"           ,false);
+            CheckAndSetParameter( parameterSet , "HCAL_ICICONTROL_MULTI"     ,false);
+            CheckAndSetParameter( parameterSet , "HCAL_PICONTROL_MULTI"      ,false);
           }
         }
         catch (UserActionException e){

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -286,7 +286,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       // ask the HCAL supervisor for the TriggerAdapter name
       //
       
-      logger.warn("[JohnLog] this FM is checking if he should be doing getTriggerAdapter() " + functionManager.FMname + " and his role is " + functionManager.FMrole);
       if (functionManager.FMrole.equals("EvmTrig")) {
         //logger.info("JohnLog3] [HCAL LVL2 " + functionManager.FMname + "] Going to ask the HCAL supervisor fo the TriggerAdapter name, now...");
         logger.info("[HCAL LVL2 " + functionManager.FMname + "] Going to ask the HCAL supervisor fo the TriggerAdapter name, now...");


### PR DESCRIPTION
Now that TCDS control sequences and CfgScripts are published to runInfo and the parsing chain is well established, time to stop filling up our logs.