### PR TITLE
H2support

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -103,6 +103,7 @@ public class HCALEventHandler extends UserEventHandler {
   public boolean stopHCALSupervisorWatchThread =  false;  // For turning off the supervisor watch thread
   public boolean stopTriggerAdapterWatchThread =  false;  // For turning off the TA thread
   public boolean stopAlarmerWatchThread        =  false;  // For turning off the alarmer thread
+  public boolean stopTTCciWatchThread          =  false;  // For turning off the TTCci thread
   public boolean delayAlarmerWatchThread       =  false;  // For delaying the alarmer thread at the start
   public boolean NotifiedControlledFMs         =  false;  // For notifications to level2s
   public boolean ClockChanged                  =  false;  // Flag for whether the clock source has changed

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -427,7 +427,9 @@ public class HCALFunctionManager extends UserFunctionManager {
     theEventHandler.stopMonitorThread = true;
     theEventHandler.stopHCALSupervisorWatchThread = true;
     theEventHandler.stopTriggerAdapterWatchThread = true;
+    theEventHandler.stopTriggerAdapterWatchThread = true;
     theEventHandler.stopAlarmerWatchThread = true; 
+    theEventHandler.stopTTCciWatchThread = true; 
     theStateNotificationHandler.setTimeoutThread(false);
 
     try{

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -1809,7 +1809,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
   public class TTCciWatchThread extends Thread {
     protected HCALFunctionManager functionManager = null;
     RCMSLogger logger = null;
-    Boolean stopTTCciWatchThread = false;
 
     public TTCciWatchThread(HCALFunctionManager parentFunctionManager) {
       this.logger = new RCMSLogger(HCALFunctionManager.class);

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -1886,6 +1886,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
             }
         } 
       }
+      logger.warn("[HCAL " + functionManager.FMname + "] ... stopping TTCci watchdog thread done.");
     }
   }
 }

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -1857,8 +1857,12 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
               // Configured To Halted
               else if(functionManager.getState().getStateString().equals(HCALStates.CONFIGURED.toString())){
                 functionManager.firePriorityEvent(HCALInputs.SETHALT);
-              //} else if(functionManager.getState().getStateString().equals(HCALStates.HALTED.toString())){
-              } else 
+              }
+              // Halting to Halted
+              else if(functionManager.getState().getStateString().equals(HCALStates.HALTING.toString())){
+                functionManager.firePriorityEvent(HCALInputs.SETHALT);
+              }
+              else 
               {
                   //Sleep when we are in HALTED
                   try {


### PR DESCRIPTION
TTCciWatchThread needs to do the `Halting to Halted` as we enforced `Halt+Destroy` at the end of run now.
Also added explicit stop of the TTCciWatchThread with `stopTTCciWatchThread`.
This is tested at H2.