### PR TITLE
Propogate running degraded

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2571,7 +2571,9 @@ public class HCALEventHandler extends UserEventHandler {
             if(!functionManager.getState().getStateString().equals(HCALStates.RUNNINGDEGRADED.toString())) {
               String errMessage = "[HCAL " + functionManager.FMname + "] Error! Got an exception: AlarmerWatchThread()\n...\nHere is the exception: " +e+"\n...going to change to RUNNINGDEGRADED state";
               logger.error(errMessage);
-              functionManager.fireEvent(HCALInputs.SETRUNNINGDEGRADED);
+              Input degradeInput = new Input(HCALInputs.SETRUNNINGDEGRADED);
+              degradeInput.setReason("Cannot get monitoring data from alarmer due to XdaqException");
+              functionManager.fireEvent(degradeInput);
             }
             else {
               String errMessage = "[HCAL " + functionManager.FMname + "] Error! Got an exception: AlarmerWatchThread()\n...\nHere is the exception: " +e+"\n...going to stay in RUNNINGDEGRADED state";

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2535,19 +2535,19 @@ public class HCALEventHandler extends UserEventHandler {
                 // total status not OK and FMstate != RunningDegraded => go to degraded state 
                 if(!FMstate.equals(HCALStates.RUNNINGDEGRADED.toString())) {
                   logger.warn("[HCAL " + functionManager.FMname + "] AlarmerWatchThread: due to bad alarmer status (see previous messages), going to RUNNINGDEGRADED state");
-                  String errMessage = "Running degraded due to";
+                  String runningDegradedReason = "Running degraded due to";
                   for (String partitionName : badAlarmerPartitions){
                     if (ignoredPartitions.contains(partitionName)){
                       continue;
                     }
-                    String partitionMessage  = pam.getValue(partitionName+"_Message");
-                    if (partitionMessage!=null){
-                      errMessage += " " + partitionName + ":" + partitionMessage;
+                    String alarmDetails  = pam.getValue(partitionName+"_Message");
+                    if (alarmDetails!=null){
+                      runningDegradedReason += " " + partitionName + ":" + alarmDetails " |";
                     }
                   }
-                  logger.warn(errMessage);
+                  logger.warn("[HCAL HCAL_LEVEL_1] AlarmerWatchThread(): Setting running degraded reason to" + runningDegradedReason);
                   Input degradeInput = new Input(HCALInputs.SETRUNNINGDEGRADED);
-                  degradeInput.setReason(errMessage);
+                  degradeInput.setReason(runningDegradedReason);
                   functionManager.fireEvent(degradeInput);
                   functionManager.setAction(badAlarmerMessage);
                 }

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2542,7 +2542,7 @@ public class HCALEventHandler extends UserEventHandler {
                     }
                     String alarmDetails  = pam.getValue(partitionName+"_Message");
                     if (alarmDetails!=null){
-                      runningDegradedReason += " " + partitionName + ":" + alarmDetails " |";
+                      runningDegradedReason += " " + partitionName + ":" + alarmDetails + " |";
                     }
                   }
                   logger.warn("[HCAL HCAL_LEVEL_1] AlarmerWatchThread(): Setting running degraded reason to" + runningDegradedReason);
@@ -2569,10 +2569,10 @@ public class HCALEventHandler extends UserEventHandler {
           catch (Exception e) {
             // on exceptions, we go to degraded, or stay there
             if(!functionManager.getState().getStateString().equals(HCALStates.RUNNINGDEGRADED.toString())) {
-              String errMessage = "[HCAL " + functionManager.FMname + "] Error! Got an exception: AlarmerWatchThread()\n...\nHere is the exception: " +e+"\n...going to change to RUNNINGDEGRADED state";
+              String errMessage = "[HCAL " + functionManager.FMname + "] Error! Got an exception: AlarmerWatchThread()\n...\nHere is the exception: " +e.getMessage()+"\n...going to change to RUNNINGDEGRADED state";
               logger.error(errMessage);
               Input degradeInput = new Input(HCALInputs.SETRUNNINGDEGRADED);
-              degradeInput.setReason("Cannot get monitoring data from alarmer due to XdaqException");
+              degradeInput.setReason("Cannot get monitoring data from alarmer due to Exception: " + e.getMessage());
               functionManager.fireEvent(degradeInput);
             }
             else {

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -201,7 +201,10 @@ public class HCALMasker {
         if (functionManager.RunType.equals("local")){
           qr.getResource().setRole("EvmTrig");
           functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("EVM_TRIG_FM", new StringT(qr.getName())));
-         }
+        }
+        else if (functionManager.RunType.equals("global")){
+          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("EVM_TRIG_FM", new StringT("")));
+        }
       }
       try {
         QualifiedGroup level2group = ((FunctionManager)qr).getQualifiedGroup();

--- a/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
+++ b/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
@@ -74,6 +74,8 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
         }
 
         handleError(errMsg,actionMsg);
+        //logger.warn("["+fm.FMname+"]: Going to error, reset taskSequence to null. ");
+        taskSequence = null;  //Reset taskSequence if we are in error
         return;
       }
       //INFO [SethLog HCAL HCAL_HO] 2 received id: http://hcalvme05.cms:16601/urn:xdaq-application:lid=50, ToState: Ready

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -185,8 +185,8 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       if(MasterSnippetList!=""){
         NodeList nodes = xmlHandler.getHCALuserXML(CfgCVSBasePath,MasterSnippetList).getElementsByTagName("RunConfig");
         for (int i=0; i < nodes.getLength(); i++) {
-          logger.debug("[HCAL " + functionManager.FMname + "]: Item " + i + " has node name: " + nodes.item(i).getAttributes().getNamedItem("name").getNodeValue() 
-              + ", snippet name: " + nodes.item(i).getAttributes().getNamedItem("snippet").getNodeValue()+ ", and maskedapps: " + nodes.item(i).getAttributes().getNamedItem("maskedapps").getNodeValue());
+          //logger.debug("[HCAL " + functionManager.FMname + "]: Item " + i + " has node name: " + nodes.item(i).getAttributes().getNamedItem("name").getNodeValue() 
+          //    + ", snippet name: " + nodes.item(i).getAttributes().getNamedItem("snippet").getNodeValue()+ ", and maskedapps: " + nodes.item(i).getAttributes().getNamedItem("maskedapps").getNodeValue());
           
           MapT<StringT> RunKeySetting = new MapT<StringT>();
           StringT runkeyName =new StringT(nodes.item(i).getAttributes().getNamedItem("name").getNodeValue());
@@ -1727,14 +1727,9 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
     VectorT<StringT> MaskedResources    = (VectorT<StringT>)functionManager.getHCALparameterSet().get("MASKED_RESOURCES").getValue();
     MapT<MapT<StringT>> LocalRunKeyMap  = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("AVAILABLE_RUN_CONFIGS").getValue();
 
-    if (MaskedResources.isEmpty()){
+    if (RunType.equals("global") && MaskedResources.isEmpty()){
       if(LocalRunKeyMap.get(runkeyName)!= null){
-        if(LocalRunKeyMap.get(runkeyName).get(new StringT("maskedFM"))!=null){
-          String[] maskedFMs       = LocalRunKeyMap.get(runkeyName).get(new StringT("maskedFM")).getString().split(";");
-          for (String fm:maskedFMs){
-            MaskedResources.add(new StringT(fm));
-          }
-        }
+        // Note: Unlike maskedapps here, maskedFM is not to be used in global
         if(LocalRunKeyMap.get(runkeyName).get(new StringT("maskedapps"))!=null){
           String[] maskedapps      = LocalRunKeyMap.get(runkeyName).get(new StringT("maskedapps")).getString().split("\\|");
           for (String app:maskedapps){

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -483,7 +483,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         }
         catch (QualifiedResourceContainerException e) {
           String errMessage = "[HCAL LVL1 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: sending: " + HCALInputs.RESET + " failed ...";
-          functionManager.goToError(errMessage,e)
+          functionManager.goToError(errMessage,e);
         }
       }
       else {

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -474,12 +474,6 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("Resetting")));
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("SUPERVISOR_ERROR",new StringT("")));
 
-      // kill all XDAQ executives
-      //destroyXDAQ();
-
-      // init all XDAQ executives
-      //initXDAQ();
-
       if (!functionManager.containerFMChildren.isEmpty()) {
 
         // reset all FMs
@@ -489,11 +483,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         }
         catch (QualifiedResourceContainerException e) {
           String errMessage = "[HCAL LVL1 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: sending: " + HCALInputs.RESET + " failed ...";
-          logger.error(errMessage,e);
-          functionManager.sendCMSError(errMessage);
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - problems ...")));
-          if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return;}
+          functionManager.goToError(errMessage,e)
         }
       }
       else {


### PR DESCRIPTION
Propogate running degraded details to LV0 through setReason. When the system enters running degraded due to degraded partitions it will set the reason as a list of degraded partitions paired with the details of what caused the degrading.

This pull request also includes code for automasking of readout apps as this was necessary in order to test the code wit the minidaq run.