### PR TITLE
Partition ignore case

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2375,18 +2375,39 @@ public class HCALEventHandler extends UserEventHandler {
       // TODO: Watch "Dev" partition base on a FM parameter
       
       List<QualifiedResource> fmChildrenList    = functionManager.containerFMChildren.getActiveQRList();
-      List<String>  watchedAlarms     = new ArrayList<String>();
-      List<String>  watchedPartitions = new ArrayList<String>();
+      List<String>  watchedAlarms     = new ArrayList<String>();  //All parameters to query
+      List<String>  watchedPartitions = new ArrayList<String>();  //All watchedPartitions (LV2 names)
+      List<String>  AlarmerPamNames   = new ArrayList<String>();  //All alarmer pam Names
       String        FMstate           =  functionManager.getState().getStateString();
+      XDAQParameter NameQuery         = new XDAQParameter(functionManager.alarmerURL,"hcalAlarmer",0);
+      HashMap<String,String> partitionStatusMap  = new HashMap<String,String>(); // e.g. <HO,HO_Status>,<Laser,LASER_Status>
+      HashMap<String,String> partitionMessageMap = new HashMap<String,String>(); // e.g. <HO,HO_Message>,<Laser,LASER_Message>
+      try{
+        AlarmerPamNames = NameQuery.getNames();
+      }
+      catch(XDAQException e){
+        logger.error("[HCAL "+functionManager.FMname+"] AlarmerWatchThread: Cannot get alarmer infospace parameter names. Exception: "+e.getMessage());
+      }
       for(QualifiedResource qr : fmChildrenList){
         String LV2FMname             = qr.getName(); //e.g. HCAL_HO
         try{
           // Get FM_PARTITION from the LV2 parameterSet 
           String partition = ((StringT)(((FunctionManager)qr).getParameter().get("FM_PARTITION").getValue())).getString();
           if (!partition.equals("not set")){
-             watchedAlarms.add(partition+"_Message"); //e.g. HO_Message
-            watchedAlarms.add(partition+"_Status"); //e.g. HO_Status
-            watchedPartitions.add(partition);       //e.g. HO
+            for(String pamName : AlarmerPamNames){
+              //Match partition names with AlarmerInfospace parameters ignore case
+              if(pamName.toLowerCase().contains(partition.toLowerCase()) && pamName.contains("_Status")  ){
+                //Use Infospace partition name for query
+                watchedAlarms.add(pamName);                                    //e.g. HO_Status
+                //Use FMname partition name for ignoring Empty/Masked FMs
+                watchedPartitions.add(partition);                              //e.g. HO
+                partitionStatusMap.put(partition,pamName);
+              }
+              if(pamName.toLowerCase().contains(partition.toLowerCase()) && pamName.contains("_Message")  ){
+                watchedAlarms.add(pamName);                                   //e.g. HO_Message
+                partitionMessageMap.put(partition,pamName);
+              }
+            }
           }
           else{
             logger.warn("[HCAL " + functionManager.FMname+"] AlarmerWatchThread: not watching this partition: "+partition+" because LV2:"+LV2FMname+" has no supervisor");
@@ -2463,7 +2484,7 @@ public class HCALEventHandler extends UserEventHandler {
             pam.select(watchedAlarms_Str);
             pam.get();
             for (String thisPartition : watchedPartitions) {
-              String thisAlarm           = thisPartition+"_Status";
+              String thisAlarm           = partitionStatusMap.get(thisPartition);
               if (pam.getValue(thisAlarm)!=null){
                 String alarmerStatusString = pam.getValue(thisAlarm);
                 partitionStatusStrings.put(thisPartition, alarmerStatusString);
@@ -2502,7 +2523,7 @@ public class HCALEventHandler extends UserEventHandler {
               // Print debug partition results
               logger.debug("[HCAL " + functionManager.FMname + "] HCALEventHandler: alarmerWatchThread : Printing partition statuses:");
               for (String partitionName : watchedPartitions) {
-                String thisPartitionAlarmerResults = "[HCAL " + functionManager.FMname + "] David log : Partition " + partitionName + " / alarm " + partitionName + "_Status => ";
+                String thisPartitionAlarmerResults = "[HCAL " + functionManager.FMname + "] David log : Partition " + partitionName + " / alarm " + partitionStatusMap.get(partitionName) + " => ";
                 if (partitionStatuses.get(partitionName)) {
                   thisPartitionAlarmerResults = thisPartitionAlarmerResults + " OK";
                 } else {
@@ -2540,7 +2561,7 @@ public class HCALEventHandler extends UserEventHandler {
                     if (ignoredPartitions.contains(partitionName)){
                       continue;
                     }
-                    String alarmDetails  = pam.getValue(partitionName+"_Message");
+                    String alarmDetails  = pam.getValue(partitionMessageMap.get(partitionName));
                     if (alarmDetails!=null){
                       runningDegradedReason += " " + partitionName + ":" + alarmDetails + " |";
                     }

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -1760,16 +1760,19 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
     MapT<MapT<StringT>> LocalRunKeyMap = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("AVAILABLE_RUN_CONFIGS").getValue();
 
     if (LocalRunKeyMap.get(runkeyName).get(new StringT("maskedapps"))!=null){
-      String[] maskedapps         = LocalRunKeyMap.get(runkeyName).get(new StringT("maskedapps")).getString().split("\\|");
-      String errorMessage         = "";
-      for (String app:maskedapps){
-        String[] appArray = app.split("\\_");
-        if (appArray.length != 2 || isValidInstanceNumber(appArray[0]) || !(isValidInstanceNumber(appArray[1]))){
-          errorMessage = errorMessage + " " + app;
+      String   allmaskedapps      = LocalRunKeyMap.get(runkeyName).get(new StringT("maskedapps")).getString();
+      if(allmaskedapps !=""){
+        String[] maskedapps         = allmaskedapps.split("\\|");
+        String errorMessage         = "";
+        for (String app:maskedapps){
+          String[] appArray = app.split("\\_");
+          if (appArray.length != 2 || isValidInstanceNumber(appArray[0]) || !(isValidInstanceNumber(appArray[1]))){
+            errorMessage = errorMessage + " " + app;
+          }
         }
-      }
-      if (errorMessage != ""){
-        throw new UserActionException("Runkey " + runkeyName +" maskedapps incorrectly formated:" + errorMessage); 
+        if (errorMessage != ""){
+          throw new UserActionException("Runkey " + runkeyName +" maskedapps incorrectly formated:" + errorMessage); 
+        }
       }
     }
   }


### PR DESCRIPTION
Hot fixes for P5:
- hcos has partition naming convention with all capital letters:
https://gitlab.cern.ch/cmshcos/hcal/blob/release/hcalBase/src/common/CrateInfo.cc#L16
So we allow partition name from FM to have different cases in alarmer.
- `checkMaskedappsFormat` did not allow having a maskedapp attribute in the runkey with empty content. Skipped checking if content is empty.