### PR TITLE
New stop sequence

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -521,11 +521,11 @@ public class HCALEventHandler extends UserEventHandler {
           if (TimeOut!=0) {
             while ((!status.equals("Ready")) && (!status.equals("Failed")) && (elapsedseconds<=TimeOut)) {
               try {
-                if (elapsedseconds%10==0) {
-                  logger.debug("[HCAL " + functionManager.FMname + "] asking for the TriggerAdapter stateName after requesting: " + TriggersToTake + " events (with " + TimeOut + "sec time out enabled) ...");
+                if (elapsedseconds%1==0) {
+                  logger.info("[HCAL " + functionManager.FMname + "] asking for the TriggerAdapter stateName after requesting: " + TriggersToTake + " events (with " + TimeOut + "sec time out enabled) ...");
                 }
 
-                elapsedseconds +=5;
+                elapsedseconds +=1;
                 try { Thread.sleep(1000); }
                 catch (Exception ignored) {}
 


### PR DESCRIPTION
Implement issues discussed in #280 . 
 `waitforTriggerAdapter` is supposed to wait for the last batch of triggers after issuing disable to TA, but the counting of sleep loop was incorrect, so this could cause the hcos issue during stopping[1]. Fixed the waiting loop in 2fcb2da.
After some more thoughts, the difficulty in stopping seems to be coming from the stopping all LV2 FM in parallel without ordering. Scheduling EvmTrig FM to stop first should be a more appropriate solution.

Tested at 904 with 
1)normal config with 1uTCA+1VME+[LPM], 
2) minidaq runs and
3) localDAQ single Partition 
for click-stop  and run to completion. Sequence works without problem.

[1]https://gitlab.cern.ch/cmshcos/hcal/issues/25