### PR TITLE
Improve masking panel

### DIFF
--- a/gui/css/hcalcontrol.css
+++ b/gui/css/hcalcontrol.css
@@ -332,7 +332,7 @@ body {
 .control_wrapper {
   position: relative;
   left: -15px;
-  display: inline;
+  display: flex;
   pointer-events: none;
 }
 .control__indicator {
@@ -342,23 +342,14 @@ body {
   display: inline-block;
   z-index: 10;
   pointer-events: none;
-  font-size: 11px;
   position: relative;
-  top: 2px;
+  top: 5px;
   left: -1px;
-}
-.control__indicator > span {
-  position: relative;
-  left: -1px;
-  top: -3px;
-}
-.control__indicator img {
-  width: 14px;
 }
 .radio_wrapper {
   position: relative;
   left: -15px;
-  display: inline;
+  display: flex;
   pointer-events: none;
 }
 .radio__indicator {
@@ -368,24 +359,24 @@ body {
   display: inline-block;
   z-index: 10;
   pointer-events: none;
-  font-size: 11px;
   position: relative;
-  top: 2px;
+  top: 5px;
   left: -1px;
 }
-.radio__indicator > span {
+.partitionSelection input{
+  z-index: 11;
+  opacity: 0;
+  float: left;
+}
+.partitionSelection li {
+  display: table;
+}
+.partitionSelection img {
+  width: 14px;
+}
+.partitionSelection span {
+  width: 14px;
   position: relative;
   left: -1px;
   top: -3px;
-}
-.radio__indicator img {
-  width: 14px;
-}
-#multiPartitionSelection input{
-  z-index: 11;
-  opacity: 0;
-}
-#singlePartitionSelection input{
-  z-index: 11;
-  opacity: 0;
 }

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -345,8 +345,8 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
                                     <div>
                                       Masked FMs: <span id="maskTest"></span>
                                       <div>
-                                        <div id="multiPartitionSelection" class="tbl"></div>
-                                        <div id="singlePartitionSelection" class="tbl"></div>
+                                        <div id="multiPartitionSelection" class="partitionSelection"></div>
+                                        <div id="singlePartitionSelection" class="partitionSelection"></div>
                                      </div>
                                    </div>
                                   </div>


### PR DESCRIPTION
The masking panel looked funny on the FNAL teststand:
![image](https://user-images.githubusercontent.com/8178838/30977004-e0527700-a43b-11e7-8136-c4815d8db216.png)

With this change, it looks like this:
![image](https://user-images.githubusercontent.com/8178838/30976946-b9416270-a43b-11e7-8365-20b855478076.png)

I also tested the display after adding a whole bunch more to the list, and it looks fine, but it would be nice to test at P5 and 904 to make sure it looks OK there.