### PR TITLE
Fix masking panels for broken grandmaster case

### DIFF
--- a/gui/css/hcalcontrol.css
+++ b/gui/css/hcalcontrol.css
@@ -363,6 +363,9 @@ body {
   top: 5px;
   left: -1px;
 }
+.partitionSelection {
+  display: none;
+}
 .partitionSelection input{
   z-index: 11;
   opacity: 0;


### PR DESCRIPTION
A refinement for earlier PR #309. Initially I thought this `display: none` was superfluous (the masking panels inherited this css property from the css class `tbl` which had `display: none`, but I replaced `tbl` with `partitionSelection` and omitted the `display: none`). Martin observed behavior that might be related to that, however, so I've stuck it back in.