### PR TITLE
Get number of events to take visible in gui when runkey is picked

### DIFF
--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -139,6 +139,10 @@ function mirrorSelection() {
     $('#CFGSNIPPET_KEY_SELECTED').val($('#dropdown option:selected').text());
     $('#RUN_CONFIG_SELECTED').val($('#dropdown option:selected').val());
     //$('#MASKED_RESOURCES').val($('#dropdown option:selected').attr("maskedresources"));
+    if ($('#dropdown option:selected').attr("eventsToTake") != "default") {
+      $('#newNUMBER_OF_EVENTScheckbox :checkbox').click();
+      $('#NUMBER_OF_EVENTS').val($('#dropdown option:selected').attr("eventsToTake"));
+    }
 }
 
 function checkCheckboxes() {
@@ -180,7 +184,9 @@ function makedropdown(availableRunConfigs, availableLocalRunKeys) {
         if (runConfigMap[localRunKeysArray[i]].hasOwnProperty('maskedFM')) { maskedFM=runConfigMap[localRunKeysArray[i]].maskedFM; }
         singlePartitionFM = "";
         if (runConfigMap[localRunKeysArray[i]].hasOwnProperty('singlePartitionFM')) { singlePartitionFM=runConfigMap[localRunKeysArray[i]].singlePartitionFM; }
-        dropdownoption = dropdownoption + "<option value='" + runConfigMap[localRunKeysArray[i]].snippet + "' maskedresources='" + runConfigMap[localRunKeysArray[i]].maskedapps +"' maskedFM='" + maskedFM + "' + singlePartitionFM='" + singlePartitionFM + "' >" + localRunKeysArray[i] + "</option>";
+        eventsToTake = "default";
+        if (runConfigMap[localRunKeysArray[i]].hasOwnProperty('eventsToTake')) { eventsToTake=runConfigMap[localRunKeysArray[i]].eventsToTake; }
+        dropdownoption = dropdownoption + "<option value='" + runConfigMap[localRunKeysArray[i]].snippet + "' maskedresources='" + runConfigMap[localRunKeysArray[i]].maskedapps +"' maskedFM='" + maskedFM + "' + singlePartitionFM='" + singlePartitionFM + "' eventsToTake='" + eventsToTake+ "' >" + localRunKeysArray[i] + "</option>";
     }
     dropdownoption = dropdownoption + "</select>";
     $('#dropdowndiv').html(dropdownoption);

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -768,17 +768,14 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         functionManager.goToError(e.getMessage());
       }
 
-      //Check if the NUMBER_OF_EVENTS parameter is already set from GUI, if so, ignore settings from mastersnippet
-      boolean NeventIsSetFromGUI = !xmlHandler.hasDefaultValue("NUMBER_OF_EVENTS",1000);
-
       if(!CommonMasterSnippetFile.equals("")){    
           //parse and set HCAL parameters from CommonMasterSnippet
           logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet : "+ CommonMasterSnippetFile);
-          xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath,NeventIsSetFromGUI);
+          xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath);
       }
       //Parse and set HCAL parameters from MasterSnippet
       logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
-      xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath,NeventIsSetFromGUI);
+      xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath);
 
       //Pring results from mastersnippet:
       logger.info("[HCAL LVL1 " + functionManager.FMname + "]  Printing results from parsing Mastersnippet(s): ");

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -194,6 +194,9 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           if ( ((Element)nodes.item(i)).hasAttribute("singlePartitionFM")){
             RunKeySetting.put(new StringT("singlePartitionFM")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("singlePartitionFM").getNodeValue()));
           }
+          if ( ((Element)nodes.item(i)).hasAttribute("eventsToTake")){
+            RunKeySetting.put(new StringT("eventsToTake")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("eventsToTake").getNodeValue()));
+          }
 
           logger.debug("[HCAL " + functionManager.FMname + "]: RunkeySetting  is :"+ RunKeySetting.toString());
 

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -569,7 +569,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       if(isSinglePartition){
         //KKH: Set ICIControl from userXML if it is not empty
         if(xmlHandler.hasUniqueTag(xmlHandler.getHCALuserXML().getElementsByTagName("ICIControlSingle"),"ICIControlSingle")){
-          xmlHandler.SetHCALParameterFromTagName("ICIControlSingle",xmlHandler.getHCALuserXML().getElementsByTagName("ICIControlSingle"),CfgCVSBasePath,false);
+          xmlHandler.SetHCALParameterFromTagName("ICIControlSingle",xmlHandler.getHCALuserXML().getElementsByTagName("ICIControlSingle"),CfgCVSBasePath);
         }
         ICIControlSequence   = ((StringT)functionManager.getHCALparameterSet().get("HCAL_ICICONTROL_SINGLE" ).getValue()).getString();
         PIControlSequence    = ((StringT)functionManager.getHCALparameterSet().get("HCAL_PICONTROL_SINGLE"   ).getValue()).getString();
@@ -577,7 +577,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       else{
         //KKH: Set ICIControl from userXML if it is not empty
         if(xmlHandler.hasUniqueTag(xmlHandler.getHCALuserXML().getElementsByTagName("ICIControlMulti"),"ICIControlMulti")){
-          xmlHandler.SetHCALParameterFromTagName("ICIControlMulti",xmlHandler.getHCALuserXML().getElementsByTagName("ICIControlMulti"),CfgCVSBasePath,false);
+          xmlHandler.SetHCALParameterFromTagName("ICIControlMulti",xmlHandler.getHCALuserXML().getElementsByTagName("ICIControlMulti"),CfgCVSBasePath);
         }
         ICIControlSequence   = ((StringT)functionManager.getHCALparameterSet().get("HCAL_ICICONTROL_MULTI" ).getValue()).getString();
         PIControlSequence    = ((StringT)functionManager.getHCALparameterSet().get("HCAL_PICONTROL_MULTI"   ).getValue()).getString();

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -660,6 +660,11 @@ public class HCALxmlHandler {
           functionManager.alarmerPartition  = getTagAttribute(NodeListOfTagName,TagName,"partition" );
       }
       if(TagName.equals("FMSettings")){
+          // Place holder to trying to set NumberOfEvents from Mastersnippet
+          String  StringNumberOfEvents      = getTagAttribute(NodeListOfTagName, TagName,"NumberOfEvents");
+          if( !StringNumberOfEvents.equals("")){
+            logger.warn("[HCAL "+functionManager.FMname+"] NumberOfEvents found in MasterSnippet! This feature has been deprecated. Use \'eventsToTake\' in runkey instead"); 
+          }
           //Set the parameters if the attribute exists in the element, otherwise will use default in HCALParameter
           String  StringRunInfoPublish      = getTagAttribute(NodeListOfTagName, TagName,"RunInfoPublish");
           if( !StringRunInfoPublish.equals("")){

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -466,7 +466,7 @@ public class HCALxmlHandler {
   }
 
   // Fill parameters from MasterSnippet
-  public void parseMasterSnippet(String selectedRun, String CfgCVSBasePath, boolean NeventIsSetFromGUI ) throws UserActionException{
+  public void parseMasterSnippet(String selectedRun, String CfgCVSBasePath) throws UserActionException{
     try{
         // Get ControlSequences from mastersnippet
         docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -488,7 +488,7 @@ public class HCALxmlHandler {
                 SetHCALFMParameter(iElement);
               } else {
                 NodeList iNodeList = masterSnippetElement.getElementsByTagName( iTagName ); 
-                SetHCALParameterFromTagName( iTagName , iNodeList, CfgCVSBasePath, NeventIsSetFromGUI);
+                SetHCALParameterFromTagName( iTagName , iNodeList, CfgCVSBasePath);
               }
             }
           }
@@ -646,7 +646,7 @@ public class HCALxmlHandler {
   }
 
 
-  public void SetHCALParameterFromTagName(String TagName, NodeList NodeListOfTagName ,String CfgCVSBasePath, boolean NeventIsSetFromGUI){
+  public void SetHCALParameterFromTagName(String TagName, NodeList NodeListOfTagName ,String CfgCVSBasePath){
     try{
       if(TagName.equals("ICIControlSingle")|| TagName.equals("ICIControlMulti") || TagName.equals("LPMControl")|| TagName.equals("PIControlSingle")||TagName.equals("PIControlMulti") || TagName.equals("TTCciControl") || TagName.equals("LTCControl") ){
           String HCALParameter = getHCALParameterFromTagName(TagName);
@@ -660,17 +660,6 @@ public class HCALxmlHandler {
           functionManager.alarmerPartition  = getTagAttribute(NodeListOfTagName,TagName,"partition" );
       }
       if(TagName.equals("FMSettings")){
-          //Set the parameters if the attribute exists in the element, otherwise will use default in HCALParameter
-          String StringNumberOfEvents       = getTagAttribute(NodeListOfTagName, TagName,"NumberOfEvents");
-          if(NeventIsSetFromGUI){
-            logger.info("[HCAL LVL1 "+functionManager.FMname+" Number of Events already set to "+ functionManager.getHCALparameterSet().get("NUMBER_OF_EVENTS").getValue()+" from GUI. Not over-writting");
-          }
-          else{
-            if( !StringNumberOfEvents.equals("")){
-               Integer NumberOfEvents           = Integer.valueOf(StringNumberOfEvents);
-               functionManager.getHCALparameterSet().put(new FunctionManagerParameter<IntegerT>("NUMBER_OF_EVENTS",new IntegerT(NumberOfEvents)));
-            }
-          }
           //Set the parameters if the attribute exists in the element, otherwise will use default in HCALParameter
           String  StringRunInfoPublish      = getTagAttribute(NodeListOfTagName, TagName,"RunInfoPublish");
           if( !StringRunInfoPublish.equals("")){


### PR DESCRIPTION
Attempt at doing #152. The number of events will instantly populate the GUI when an optional node `eventsToTake` is added to a RunConfig in the grandmaster, e.g.:
```
  <RunConfig name='test2' snippet='Master/uTCA_ngHB_ped.xml' maskedapps='hcal::uHTRSource_0|hcal::ngRBXSequencer_0' eventsToTake='1337' />
```
Tested at FNAL, seems to work just fine. Please test further.

With this change, we can try to refine the `NeventIsSetFromGUI` logic currently in the code.