### PR TITLE
Automate "Set Enabled Parameters"+"Initialize"+"Configure"

### DIFF
--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -105,8 +105,10 @@ function updatePage() {
       cachedNevents = $('#NUMBER_OF_EVENTS').val();
       cachedSupErr = $('#SUPERVISOR_ERROR').val();
       cachedState = currentState;
-	    if ($('#EXIT').val() == "true" && currentState=="Halted" && $.fingerprint() == $('#DRIVER_IDENTIFIER').val()) { $('#Destroy').click(); }
-      //$('#commandParameterCheckBox').attr("onclick", "onClickCommandParameterCheckBox(); toggle_visibility('Blork');");
+      driving = ($.fingerprint() == $('#DRIVER_IDENTIFIER').val());
+      if ($('#EXIT').val() == "true" && currentState=="Halted" && driving) { $('#Destroy').click(); }
+      if ($('#AUTOCONFIGURE').val() == "true" && currentState=="Initial" && driving) { onClickCommandButton('Initialize'); }
+      if ($('#AUTOCONFIGURE').val() == "true" && currentState=="Halted" && driving) { onClickCommandButton('Configure'); }
     }, 750);
 
 
@@ -190,8 +192,20 @@ function makedropdown(availableRunConfigs, availableLocalRunKeys) {
     var masterSnippetArgs = "'" + masterSnippetNumber + "', 'RUN_CONFIG_SELECTED'";
     var maskedResourcesNumber = $('#MASKED_RESOURCES').attr("name").substring(20);
     var maskedResourcesArgs = "'" + maskedResourcesNumber + "', 'MASKED_RESOURCES'";
-    var onchanges = "onClickGlobalParameterCheckBox(" + cfgSnippetArgs + "); onClickGlobalParameterCheckBox(" + masterSnippetArgs + "); onClickGlobalParameterCheckBox(" + maskedResourcesArgs + "); clickboxes(); mirrorSelection(); preclickFMs(); fillMask(); automateSinglePartition(); fillDriverID();";
+    var onchanges = "onClickGlobalParameterCheckBox(" + cfgSnippetArgs + "); onClickGlobalParameterCheckBox(" + masterSnippetArgs + "); onClickGlobalParameterCheckBox(" + maskedResourcesArgs + "); clickboxes(); mirrorSelection(); preclickFMs(); fillMask(); automateSinglePartition(); fillDriverID(); makeAutoconfigureButton();";
     $('#dropdown').attr("onchange", onchanges);
+}
+
+function setAutoconfigure() {
+  $("#newAUTOCONFIGUREcheckbox :checkbox").click();
+  $("#AUTOCONFIGURE").val("true");
+  
+}
+
+function makeAutoconfigureButton() {
+    var buttonOnClicks = "setAutoconfigure(); onClickSetGlobalParameters();";
+    var autoconfigureButton = '<input id="autoconfigureButton" class="button1" onclick="' + buttonOnClicks + '" value="Autoconfigure" type="button">';
+    $(autoconfigureButton).insertAfter("#setGlobalParametersButton");
 }
 
 function fillMask() {
@@ -326,7 +340,7 @@ function setupMaskingPanels() {
            $('#newSINGLEPARTITION_MODEcheckbox :checkbox').click();
          }
          $('#SINGLEPARTITION_MODE').val("true");
-       	 $('#singlePartitionSelection :input').prop('checked', false);
+         $('#singlePartitionSelection :input').prop('checked', false);
          $('#setGlobalParametersButton').hide();
        }
        //$(panelId).parent().find("input").prop('checked', false); // maybe this does something?
@@ -438,6 +452,8 @@ function hcalOnLoad() {
     makecheckbox('newSINGLEPARTITION_MODEcheckbox', 'SINGLEPARTITION_MODE');
     copyContents(DRIVER_IDENTIFIER, newDRIVER_IDENTIFIER);
     makecheckbox('newDRIVER_IDENTIFIERcheckbox', 'DRIVER_IDENTIFIER');
+    copyContents(AUTOCONFIGURE, newAUTOCONFIGURE);
+    makecheckbox('newAUTOCONFIGUREcheckbox', 'AUTOCONFIGURE');
     hidecheckboxes();
     hideinitializebutton();
     hidelocalparams();

--- a/gui/jsp/controlPanel.jsp
+++ b/gui/jsp/controlPanel.jsp
@@ -274,6 +274,15 @@ FMPilotBean myFMPilotBean = (FMPilotBean)(pageContext.getRequest().getAttribute(
                                 <td id ="newDRIVER_IDENTIFIER" class="label_center_black">
                                 </td>
                               </tr>
+                              <tr id="autoconfigureField" style="display: none;"> 
+                                <td id="newAUTOCONFIGUREcheckbox" class="label_center_black">
+                                </td>
+                                <td class="label_left_black">
+                                  <strong>AUTOCONFIGURE</strong>
+                                </td>
+                                <td id ="newAUTOCONFIGURE" class="label_center_black">
+                                </td>
+                              </tr>
                               <tr>
                                 <td id="newNUMBER_OF_EVENTScheckbox" class="label_center_black">
                                 </td>

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -97,6 +97,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 
 		this.put( new FunctionManagerParameter<BooleanT> ("CLOCK_CHANGED"                    ,  new BooleanT(false)       ) );  // Information from level0 on whether the clock source has changed
 		this.put( new FunctionManagerParameter<BooleanT> ("USE_RESET_FOR_RECOVER"            ,  new BooleanT(true)        ) );  // Switch for changing behavior of recover button
+		this.put( new FunctionManagerParameter<BooleanT> ("AUTOCONFIGURE"                    ,  new BooleanT(false)       ) );  // Switch for triggering automatic initialize+configure
 		this.put( new FunctionManagerParameter<BooleanT> ("EXIT"                             ,  new BooleanT(false)       ) );  // Switch for triggering a halt+destroy
 		this.put( new FunctionManagerParameter<BooleanT> ("SINGLEPARTITION_MODE"             ,  new BooleanT(false)       ) );  // Switch for toggling singlepartition mode based on user selection
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -990,6 +990,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       }
 
       // set actions
+      functionManager.getHCALparameterSet().put(new FunctionManagerParameter<BooleanT>("AUTOCONFIGURE",new BooleanT(false)));
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("configureAction executed ... - we're close ...")));
 


### PR DESCRIPTION
Implements feature request #268. A new button in the GUI that says "Autoconfigure" does the same thing as the "Set Enabled Pararameters" button but also sets the new FM parameter `AUTOCONFIGURE` to `true`. `AUTOCONFIGURE` then triggers the GUI to do the automated clicks of "Initialize" and "Configure" (for the driver's GUI only, not spectators.) Once the level1 FM reaches Configured, the `AUTOCONFIGURE` parameter gets toggled back to `false` so that the auto-clicking doesn't happen if the run goes to Halted again. Tested at FNAL, please test further.