### PR TITLE
Add timestamp to supervisor errors to GUI

### DIFF
--- a/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
+++ b/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
@@ -1,5 +1,10 @@
 package rcms.fm.app.level1;
  
+import java.util.Date;
+import java.util.TimeZone;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
 import rcms.fm.fw.parameter.FunctionManagerParameter;
 import rcms.fm.fw.parameter.type.StringT;
 import rcms.fm.fw.user.UserActionException;
@@ -74,7 +79,10 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
           errMsg = "[HCAL LV2 " + fm.FMname+ "] "+ appName+" is in ERROR, the reason is: "+ notification.getReason();
         }
         else if (!fm.containerFMChildren.isEmpty()) {
-          errMsg = "[HCAL LVL1 " + fm.FMname + "] Error received: " + notification.getReason();
+          DateFormat dateFormatter = new SimpleDateFormat("M/d/yy hh:mm:ss a");
+          dateFormatter.setTimeZone(TimeZone.getDefault());
+          String TimeNow =  dateFormatter.format(new Date());
+          errMsg = "["+TimeNow+"] LV1 FM: Received error from LV2 FM: " + notification.getReason();
           fm.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("SUPERVISOR_ERROR", new StringT(errMsg)));
         }
 

--- a/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
+++ b/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
@@ -79,7 +79,7 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
           errMsg = "[HCAL LV2 " + fm.FMname+ "] "+ appName+" is in ERROR, the reason is: "+ notification.getReason();
         }
         else if (!fm.containerFMChildren.isEmpty()) {
-          DateFormat dateFormatter = new SimpleDateFormat("M/d/yy hh:mm:ss a");
+          DateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-d HH:mm:ss");
           dateFormatter.setTimeZone(TimeZone.getDefault());
           String TimeNow =  dateFormatter.format(new Date());
           errMsg = "["+TimeNow+"] LV1 FM: Received error from LV2 FM: " + notification.getReason();


### PR DESCRIPTION
Implements #329, Added timestamp. 
Supervisor now reports TCDS soap fault string in the exception message which will be propagated to the GUI. 
https://gitlab.cern.ch/cmshcos/hcal/merge_requests/143
Example error message:
![image](https://user-images.githubusercontent.com/12798013/33218267-42351a9a-d13c-11e7-8e96-83699df9b6c2.png)
