### PR TITLE
Runkey upgrade

### DIFF
--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -201,7 +201,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           if (CfgScriptNodes.getLength()>0){
             logger.info("[HCAL " + functionManager.FMname + "]: Runkey with name "+runkeyName+" has "+CfgScriptNodes.getLength()+" CfgScript nodes");
             if(CfgScriptNodes.getLength()==1){
-              RunKeySetting.put(new StringT("CfgScript")  ,new StringT(CfgScriptNodes.item(0).getTextContent()));
+              RunKeySetting.put(new StringT("CfgToAppend")  ,new StringT(CfgScriptNodes.item(0).getTextContent()));
             }
           }
 
@@ -788,9 +788,9 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       //Append CfgScript from runkey (if any)
       StringT runkeyName                 = (StringT) functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue();
       MapT<MapT<StringT>> LocalRunKeyMap = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("AVAILABLE_RUN_CONFIGS").getValue();
-      if (LocalRunKeyMap.get(runkeyName).get(new StringT("CfgScript"))!=null){
+      if (LocalRunKeyMap.get(runkeyName).get(new StringT("CfgToAppend"))!=null){
         StringT MasterSnippetCfgScript = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGSCRIPT").getValue());
-        StringT RunkeyCfgScript        = LocalRunKeyMap.get(runkeyName).get(new StringT("CfgScript"));
+        StringT RunkeyCfgScript        = LocalRunKeyMap.get(runkeyName).get(new StringT("CfgToAppend"));
         
         logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Adding Runkey CfgScript from this runkey: "+ selectedRun+" and it looks like this "+RunkeyCfgScript);
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_CFGSCRIPT",MasterSnippetCfgScript.concat(RunkeyCfgScript)));

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -177,7 +177,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           
           MapT<StringT> RunKeySetting = new MapT<StringT>();
           StringT runkeyName          =new StringT(nodes.item(i).getAttributes().getNamedItem("name").getNodeValue());
-          NodeList CfgScriptNodes     = ((Element) nodes.item(i)).getElementsByTagName("CfgScript");
+          NodeList CfgScriptNodes     = ((Element) nodes.item(i)).getElementsByTagName("CfgToAppend");
 
           if ( ((Element)nodes.item(i)).hasAttribute("snippet")){
             RunKeySetting.put(new StringT("snippet")   ,new StringT(nodes.item(i).getAttributes().getNamedItem("snippet"   ).getNodeValue()));

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -176,7 +176,8 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           //    + ", snippet name: " + nodes.item(i).getAttributes().getNamedItem("snippet").getNodeValue()+ ", and maskedapps: " + nodes.item(i).getAttributes().getNamedItem("maskedapps").getNodeValue());
           
           MapT<StringT> RunKeySetting = new MapT<StringT>();
-          StringT runkeyName =new StringT(nodes.item(i).getAttributes().getNamedItem("name").getNodeValue());
+          StringT runkeyName          =new StringT(nodes.item(i).getAttributes().getNamedItem("name").getNodeValue());
+          NodeList CfgScriptNodes     = ((Element) nodes.item(i)).getElementsByTagName("CfgScript");
 
           if ( ((Element)nodes.item(i)).hasAttribute("snippet")){
             RunKeySetting.put(new StringT("snippet")   ,new StringT(nodes.item(i).getAttributes().getNamedItem("snippet"   ).getNodeValue()));
@@ -197,8 +198,14 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           if ( ((Element)nodes.item(i)).hasAttribute("eventsToTake")){
             RunKeySetting.put(new StringT("eventsToTake")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("eventsToTake").getNodeValue()));
           }
+          if (CfgScriptNodes.getLength()>0){
+            logger.info("[HCAL " + functionManager.FMname + "]: Runkey with name "+runkeyName+" has "+CfgScriptNodes.getLength()+" CfgScript nodes");
+            if(CfgScriptNodes.getLength()==1){
+              RunKeySetting.put(new StringT("CfgScript")  ,new StringT(CfgScriptNodes.item(0).getTextContent()));
+            }
+          }
 
-          logger.debug("[HCAL " + functionManager.FMname + "]: RunkeySetting  is :"+ RunKeySetting.toString());
+          logger.info("[HCAL " + functionManager.FMname + "]: RunkeySetting  is :"+ RunKeySetting.toString());
 
           LocalRunKeys.add(runkeyName);
           LocalRunKeyMap.put(runkeyName,RunKeySetting);

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -205,7 +205,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
             }
           }
 
-          logger.info("[HCAL " + functionManager.FMname + "]: RunkeySetting  is :"+ RunKeySetting.toString());
+          logger.debug("[HCAL " + functionManager.FMname + "]: RunkeySetting  is :"+ RunKeySetting.toString());
 
           LocalRunKeys.add(runkeyName);
           LocalRunKeyMap.put(runkeyName,RunKeySetting);

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -783,6 +783,16 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       //Parse and set HCAL parameters from MasterSnippet
       logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
       xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath);
+      //Append CfgScript from runkey (if any)
+      StringT runkeyName                 = (StringT) functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue();
+      MapT<MapT<StringT>> LocalRunKeyMap = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("AVAILABLE_RUN_CONFIGS").getValue();
+      if (LocalRunKeyMap.get(runkeyName).get(new StringT("CfgScript"))!=null){
+        StringT MasterSnippetCfgScript = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGSCRIPT").getValue());
+        StringT RunkeyCfgScript        = LocalRunKeyMap.get(runkeyName).get(new StringT("CfgScript"));
+        
+        logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Adding Runkey CfgScript from this runkey: "+ selectedRun+" and it looks like this "+RunkeyCfgScript);
+        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_CFGSCRIPT",MasterSnippetCfgScript.concat(RunkeyCfgScript)));
+      }
 
       //Pring results from mastersnippet:
       logger.info("[HCAL LVL1 " + functionManager.FMname + "]  Printing results from parsing Mastersnippet(s): ");


### PR DESCRIPTION
Support adding `CfgScript` block in runkey to facilitate sourcing runs.
Tested in P5.
Implement #343 