### PR TITLE
don't appear to be in spectator mode when runkeys are broken

### DIFF
--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -75,7 +75,7 @@ function updatePage() {
         $('#externalCommands :input[value="Halt+Destroy"]').css("color", "red");
       }
     }
-    else {
+    else if ($('#AVAILABLE_LOCALRUNKEYS').text() != '[]') {
       setSpectatorDisplay();
     }
     var cachedState = $('#currentState').text();
@@ -120,7 +120,7 @@ function updatePage() {
           $('#externalCommands :input[value="Halt+Destroy"]').css("color", "red");
         }
       }
-      else {
+      else if ($('#AVAILABLE_LOCALRUNKEYS').text() != '[]') {
         setSpectatorDisplay();
       }
       if ($('#SUPERVISOR_ERROR').val() !=  cachedSupErr) { showsupervisorerror(); }


### PR DESCRIPTION
Fixes #350. Tested at FNAL. It seems that actually in this 'failure' mode, the "Destroy" button wasn't really disabled; the page said "You are in spectator mode" and the Destroy button was grayed out, but it was still clickable and worked as normal.

Anyhow I fixed it so that the button isn't grayed out and it doesn't look like spectator mode when there is an error parsing the grandmaster.

Please test further (my test was not super thorough).