### PR TITLE
Lv2 reads master

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -681,6 +681,7 @@ public class HCALEventHandler extends UserEventHandler {
     // Get list of childFMs from QG
     List<QualifiedResource> childFMs = qg.seekQualifiedResourcesOfType(new FunctionManager());
     functionManager.containerFMChildren = new QualifiedResourceContainer(childFMs);
+    functionManager.containerAllFMChildren = new QualifiedResourceContainer(childFMs);
     // Fill containerFMchildren with Active FMs only
     List<QualifiedResource> ActiveChildFMs = functionManager.containerFMChildren.getActiveQRList();
     functionManager.containerFMChildren   = new QualifiedResourceContainer(ActiveChildFMs);

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2618,48 +2618,73 @@ public class HCALEventHandler extends UserEventHandler {
     }
   }
   
-  // Function to receive parameter
+  // Function to receive parameter and set to same parameter
+  void CheckAndSetParameter(ParameterSet pSet , String PamName, boolean printResult) throws UserActionException{
+    CheckAndSetTargetParameter(pSet,PamName, PamName,printResult);
+  }
   void CheckAndSetParameter(ParameterSet pSet , String PamName) throws UserActionException{
-    CheckAndSetParameter(pSet,PamName,true);
+    CheckAndSetTargetParameter(pSet,PamName, PamName,true);
   }
 
-  void CheckAndSetParameter(ParameterSet pSet , String PamName, boolean printResult) throws UserActionException{
+
+  // Function to receive parameter and set to other parameter
+  void CheckAndSetTargetParameter(ParameterSet pSet , String InputPamName, String TargetPamName, boolean printResult) throws UserActionException{
     String inputString = getUserFunctionManager().getLastInput().getInputString();
 
-    if( pSet.get(PamName) != null){
-      if (pSet.get(PamName).getType().equals(StringT.class)){
-        String PamValue = ((StringT)pSet.get(PamName).getValue()).getString();
-        functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(PamName, new StringT(PamValue)));
-        if(printResult){
-          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
-        }
-        else{
-          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString);
-        }
-      }
-      if (pSet.get(PamName).getType().equals(IntegerT.class)){
-        Integer PamValue = ((IntegerT)pSet.get(PamName).getValue()).getInteger();
-        functionManager.getParameterSet().put(new FunctionManagerParameter<IntegerT>(PamName, new IntegerT(PamValue)));
-        if(printResult){
-          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
-        }
-        else{
-          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString);
+    if( pSet.get(InputPamName) != null){
+      if (pSet.get(InputPamName).getType().equals(StringT.class)){
+        String PamValue = ((StringT)pSet.get(InputPamName).getValue()).getString();
+        if (functionManager.getParameterSet().get(TargetPamName) != null){
+        functionManager.getParameterSet().put(new FunctionManagerParameter<StringT>(TargetPamName, new StringT(PamValue)));
+          if(printResult){
+            logger.info("[HCAL "+ functionManager.FMname +" ] Received pam:"+InputPamName+ " and set pam:"+ TargetPamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
+          }
+          else{
+            logger.info("[HCAL "+ functionManager.FMname +" ] Received pam:"+InputPamName+ " and set pam:"+ TargetPamName +" from last input= "+inputString+"." );
+          }
+        }else{
+          String errMessage = "Trying to set pam="+TargetPamName+" from input "+inputString+" but cannot find target parameter "+TargetPamName;
+          logger.error(errMessage);
+          throw new UserActionException(errMessage);
         }
       }
-      if (pSet.get(PamName).getType().equals(BooleanT.class)){
-        Boolean PamValue = ((BooleanT)pSet.get(PamName).getValue()).getBoolean();
-        functionManager.getParameterSet().put(new FunctionManagerParameter<BooleanT>(PamName, new BooleanT(PamValue)));
-        if(printResult){
-          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
+      if (pSet.get(InputPamName).getType().equals(IntegerT.class)){
+        Integer PamValue = ((IntegerT)pSet.get(InputPamName).getValue()).getInteger();
+        if (functionManager.getParameterSet().get(TargetPamName) != null){
+          functionManager.getParameterSet().put(new FunctionManagerParameter<IntegerT>(TargetPamName, new IntegerT(PamValue)));
+          if(printResult){
+            logger.info("[HCAL "+ functionManager.FMname +" ] Received pam:"+InputPamName+ " and set pam:"+ TargetPamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
+          }
+          else{
+            logger.info("[HCAL "+ functionManager.FMname +" ] Received pam:"+InputPamName+ " and set pam:"+ TargetPamName +" from last input= "+inputString+"." );
+          }
         }
         else{
-          logger.info("[HCAL "+ functionManager.FMname +" ] Received and set "+ PamName +" from last input= "+inputString);
+          String errMessage = "Trying to set pam="+TargetPamName+" from input "+inputString+" but cannot find target parameter "+TargetPamName;
+          logger.error(errMessage);
+          throw new UserActionException(errMessage);
+        }
+      }
+      if (pSet.get(InputPamName).getType().equals(BooleanT.class)){
+        Boolean PamValue = ((BooleanT)pSet.get(InputPamName).getValue()).getBoolean();
+        if (functionManager.getParameterSet().get(TargetPamName) != null){
+          functionManager.getParameterSet().put(new FunctionManagerParameter<BooleanT>(TargetPamName, new BooleanT(PamValue)));
+          if(printResult){
+            logger.info("[HCAL "+ functionManager.FMname +" ] Received pam:"+InputPamName+ " and set pam:"+ TargetPamName +" from last input= "+inputString+". Here is the set value: \n"+ PamValue);
+          }
+          else{
+            logger.info("[HCAL "+ functionManager.FMname +" ] Received pam:"+InputPamName+ " and set pam:"+ TargetPamName +" from last input= "+inputString+"." );
+          }
+        }
+        else{
+           String errMessage = "Trying to set pam="+TargetPamName+" from input "+inputString+" but cannot find target parameter "+TargetPamName;
+          logger.error(errMessage);
+          throw new UserActionException(errMessage);
         }
       }
     }
     else{
-      String errMessage =" Did not receive "+ PamName +" from last input! Please check if "+ PamName+ " was filled";
+      String errMessage =" Did not receive "+ InputPamName +" from last input= "+inputString+" ! Please check if "+ InputPamName+ " was filled";
       logger.warn(errMessage);
       throw new UserActionException(errMessage);
     }

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -121,8 +121,11 @@ public class HCALFunctionManager extends UserFunctionManager {
   // container of XdaqExecutive in the running Group.
   public XdaqApplicationContainer containerXdaqExecutive = null;
 
-  // container of all FunctionManagers in the running Group.
+  // container of all active FunctionManagers in the running Group.
   public QualifiedResourceContainer containerFMChildren = null;
+  
+  // container of all FunctionManagers in the running Group.
+  public QualifiedResourceContainer containerAllFMChildren = null;
   
   // container with the EvmTrig FunctionManager for local runs
   public QualifiedResourceContainer containerFMEvmTrig = null;

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -266,7 +266,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_RUN_TYPE",new StringT(RunType)));
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("GLOBAL_CONF_KEY",new StringT(GlobalConfKey)));
 
-        // RUN_CONFIG_SELECTED = LocalRunKey; CFGSNIPPET_KEY_SELECTED = MasterSnippet file of LocalRunKey
+        // CFGSNIPPET_KEY_SELECTED = LocalRunKey;  RUN_CONFIG_SELECTED= MasterSnippet file of LocalRunKey
         RunConfigSelected = ((StringT)functionManager.getHCALparameterSet().get("RUN_CONFIG_SELECTED").getValue()).getString();
         CfgSnippetKeySelected = ((StringT)functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue()).getString();
       }
@@ -421,8 +421,12 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       pSet.put(new CommandParameter<IntegerT>("SID", new IntegerT(Sid)));
       pSet.put(new CommandParameter<StringT>("GLOBAL_CONF_KEY", new StringT(GlobalConfKey)));
 
+      //Pass selected runkey name, mastersnippet file name, runkey map to LV2
       pSet.put(new CommandParameter<StringT>("RUN_CONFIG_SELECTED", new StringT(RunConfigSelected)));
       pSet.put(new CommandParameter<StringT>("CFGSNIPPET_KEY_SELECTED", new StringT(CfgSnippetKeySelected)));
+      MapT<MapT<StringT>> LocalRunKeyMap = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("AVAILABLE_RUN_CONFIGS").getValue();
+      pSet.put(new CommandParameter<MapT<MapT<StringT>>>("AVAILABLE_RUN_CONFIGS", LocalRunKeyMap));
+
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<VectorT<StringT>>("MASKED_RESOURCES", MaskedResources));
       pSet.put(new CommandParameter<VectorT<StringT>>("MASKED_RESOURCES", MaskedResources));
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -792,7 +792,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         StringT MasterSnippetCfgScript = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGSCRIPT").getValue());
         StringT RunkeyCfgScript        = LocalRunKeyMap.get(runkeyName).get(new StringT("CfgToAppend"));
         
-        logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Adding Runkey CfgScript from this runkey: "+ selectedRun+" and it looks like this "+RunkeyCfgScript);
+        logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Adding Runkey CfgScript from this runkey: "+ runkeyName.getString()+" and it looks like this "+RunkeyCfgScript);
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_CFGSCRIPT",MasterSnippetCfgScript.concat(RunkeyCfgScript)));
       }
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -769,26 +769,17 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       // Reset HCAL_CFGSCRIPT:
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_CFGSCRIPT",new StringT("not set")));
 
-      // Try to find a common masterSnippet from MasterSnippet
-      String CommonMasterSnippetFile ="";
+      // Parse MasterSnippet
       try{
-        String TagName="CommonMasterSnippet";
-        String attribute="file";
-        CommonMasterSnippetFile = xmlHandler.getHCALMasterSnippetTagAttribute(selectedRun,CfgCVSBasePath,TagName,attribute);
+        //Parse common+main mastersnippet to pick up all-partition settings
+        xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath,"");
       }
       catch(UserActionException e){
-        logger.error("[HCAL LVL1"+functionManager.FMname+"]: Found more than one CommonMasterSnippet tag in the mastersnippet! This is not allowed!");
-        functionManager.goToError(e.getMessage());
+        String errMessage = "[HCAL LVL1"+functionManager.FMname+"]: Failed to parse mastersnippets:";
+        functionManager.goToError(errMessage,e);
+        return;
       }
-
-      if(!CommonMasterSnippetFile.equals("")){    
-          //parse and set HCAL parameters from CommonMasterSnippet
-          logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet : "+ CommonMasterSnippetFile);
-          xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath);
-      }
-      //Parse and set HCAL parameters from MasterSnippet
-      logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
-      xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath);
+      
       //Append CfgScript from runkey (if any)
       StringT runkeyName                 = (StringT) functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue();
       MapT<MapT<StringT>> LocalRunKeyMap = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("AVAILABLE_RUN_CONFIGS").getValue();

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -945,29 +945,13 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       pSet.put(new CommandParameter<StringT>("TPG_KEY"                , new StringT(TpgKey)));
       pSet.put(new CommandParameter<StringT>("FED_ENABLE_MASK"        , new StringT(FedEnableMask)));
       pSet.put(new CommandParameter<StringT>("HCAL_CFGCVSBASEPATH"    , new StringT(CfgCVSBasePath)));
-      pSet.put(new CommandParameter<StringT>("HCAL_CFGSCRIPT"         , new StringT(FullCfgScript)));
-      pSet.put(new CommandParameter<StringT>("HCAL_TTCCICONTROL"      , new StringT(TTCciControlSequence)));
-      pSet.put(new CommandParameter<StringT>("HCAL_LTCCONTROL"        , new StringT(LTCControlSequence)));
       pSet.put(new CommandParameter<BooleanT>("SINGLEPARTITION_MODE"  , new BooleanT(isSinglePartition)));
-      // Only send the one to be used by LV2,so that run info will be consistent
-      if(isSinglePartition){
-        pSet.put(new CommandParameter<StringT>("HCAL_ICICONTROL_SINGLE"       , new StringT(ICIControlSequence)));
-        pSet.put(new CommandParameter<StringT>("HCAL_PICONTROL_SINGLE"        , new StringT(PIControlSequence)));
-      }
-      else{
-        pSet.put(new CommandParameter<StringT>("HCAL_ICICONTROL_MULTI"       , new StringT(ICIControlSequence)));
-        pSet.put(new CommandParameter<StringT>("HCAL_PICONTROL_MULTI"        , new StringT(PIControlSequence)));
-        pSet.put(new CommandParameter<StringT>("HCAL_LPMCONTROL"             , new StringT(LPMControlSequence)));
-      }
       pSet.put(new CommandParameter<BooleanT>("CLOCK_CHANGED"         , new BooleanT(ClockChanged)));
       pSet.put(new CommandParameter<BooleanT>("USE_RESET_FOR_RECOVER" , new BooleanT(UseResetForRecover)));
-      pSet.put(new CommandParameter<StringT>("HCAL_PICONTROL"         , new StringT(PIControlSequence)));
       pSet.put(new CommandParameter<BooleanT>("USE_PRIMARY_TCDS"      , new BooleanT(UsePrimaryTCDS)));
       pSet.put(new CommandParameter<StringT>("SUPERVISOR_ERROR"       , new StringT(SupervisorError)));
-      pSet.put(new CommandParameter<BooleanT>("HCAL_RUNINFOPUBLISH"   , new BooleanT(RunInfoPublish)));
       pSet.put(new CommandParameter<BooleanT>("OFFICIAL_RUN_NUMBERS"  , new BooleanT(OfficialRunNumbers)));
       pSet.put(new CommandParameter<VectorT<StringT>>("EMPTY_FMS"              , EmptyFMs));
-      pSet.put(new CommandParameter<StringT>("DQM_TASK"               , new StringT(DQMtask)));
 
       // prepare command plus the parameters to send
       Input configureInput= new Input(HCALInputs.CONFIGURE.toString());

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -460,7 +460,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         try{
           // Determine the run type from the configure command
           CheckAndSetParameter(       parameterSet, "HCAL_RUN_TYPE" );
-          CheckAndSetTargetParameter( parameterSet, "HCAL_RUN_TYPE" ,"CONFIGURED_WITH_RUN_KEY",true);
+          CheckAndSetParameter(       parameterSet, "RUN_KEY");
+          CheckAndSetTargetParameter( parameterSet, "RUN_KEY" ,"CONFIGURED_WITH_RUN_KEY",true);
 
           // Check and receive TPG key
           CheckAndSetTargetParameter( parameterSet, "TPG_KEY" ,"CONFIGURED_WITH_TPG_KEY",true);

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -498,16 +498,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           CheckAndSetParameter( parameterSet , "HCAL_CFGCVSBASEPATH" );
           CheckAndSetParameter( parameterSet , "SINGLEPARTITION_MODE");
           isSinglePartition   = ((BooleanT)functionManager.getHCALparameterSet().get("SINGLEPARTITION_MODE").getValue()).getBoolean();
-          // Only set the parameter being used so that RunInfo will be clear
-          if(isSinglePartition){
-            CheckAndSetParameter( parameterSet , "HCAL_ICICONTROL_SINGLE"     ,false);
-            CheckAndSetParameter( parameterSet , "HCAL_PICONTROL_SINGLE"      ,false);
-          }
-          else{
-            CheckAndSetParameter( parameterSet , "HCAL_LPMCONTROL"           ,false);
-            CheckAndSetParameter( parameterSet , "HCAL_ICICONTROL_MULTI"     ,false);
-            CheckAndSetParameter( parameterSet , "HCAL_PICONTROL_MULTI"      ,false);
-          }
         }
         catch (UserActionException e){
           String warnMessage = "[HCAL LVL2 " + functionManager.FMname + "] ConfigureAction: "+e.getMessage();
@@ -528,16 +518,16 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         CommonMasterSnippetFile = xmlHandler.getHCALMasterSnippetTagAttribute(selectedRun,CfgCVSBasePath,TagName,attribute);
       }
       catch(UserActionException e){
-        logger.error("[HCAL LVL1"+functionManager.FMname+"]: Found more than one CommonMasterSnippet tag in the mastersnippet! This is not allowed!");
+        logger.error("[HCAL LVL2"+functionManager.FMname+"]: Found more than one CommonMasterSnippet tag in the mastersnippet! This is not allowed!");
         functionManager.goToError(e.getMessage());
       }
       if(!CommonMasterSnippetFile.equals("")){    
           //parse and set HCAL parameters from CommonMasterSnippet
-          logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet : "+ CommonMasterSnippetFile);
+          logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet : "+ CommonMasterSnippetFile);
           xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath);
       }
       //Parse and set HCAL parameters from MasterSnippet
-      logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
+      logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
       xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath);
       //Append CfgScript from runkey (if any)
       StringT runkeyName                 = (StringT) functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue();
@@ -546,7 +536,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         StringT MasterSnippetCfgScript = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGSCRIPT").getValue());
         StringT RunkeyCfgScript        = LocalRunKeyMap.get(runkeyName).get(new StringT("CfgToAppend"));
         
-        logger.info("[HCAL LVL1 "+ functionManager.FMname +"] Adding Runkey CfgScript from this runkey: "+ runkeyName.getString()+" and it looks like this "+RunkeyCfgScript);
+        logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Adding Runkey CfgScript from this runkey: "+ runkeyName.getString()+" and it looks like this "+RunkeyCfgScript);
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_CFGSCRIPT",MasterSnippetCfgScript.concat(RunkeyCfgScript)));
       }
 

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -529,6 +529,15 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       //Parse and set HCAL parameters from MasterSnippet
       logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
       xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath);
+
+      if(!CommonMasterSnippetFile.equals("")){    
+          //parse and set HCAL parameters from CommonMasterSnippet
+          logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet(partition specific) : "+ CommonMasterSnippetFile);
+          xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath,functionManager.FMpartition);
+      }
+      logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse MasterSnippet(partition specific): "+ selectedRun);
+      xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath,functionManager.FMpartition);
+
       //Append CfgScript from runkey (if any)
       StringT runkeyName                 = (StringT) functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue();
       MapT<MapT<StringT>> LocalRunKeyMap = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("AVAILABLE_RUN_CONFIGS").getValue();

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -453,37 +453,12 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
       else {
         // Determine the run type from the configure command
-        if (parameterSet.get("HCAL_RUN_TYPE") != null) {
-          RunType = ((StringT)parameterSet.get("HCAL_RUN_TYPE").getValue()).getString();
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_RUN_TYPE",new StringT(RunType)));
-        }
-        else {
-          String warnMessage = "[HCAL LVL2 " + functionManager.FMname + "] Warning! Did not receive a run type ...\nThis is OK for e.g. CASTOR LVL2 FMs directly connected to the CDAQ LVL0 FM";
-          logger.warn(warnMessage);
-        }
+        CheckAndSetParameter(       parameterSet, "HCAL_RUN_TYPE" );
+        CheckAndSetTargetParameter( parameterSet, "HCAL_RUN_TYPE" ,"CONFIGURED_WITH_RUN_KEY",true);
 
-        // get the run key from the configure command
-        if (parameterSet.get("RUN_KEY") != null) {
-          RunKey = ((StringT)parameterSet.get("RUN_KEY").getValue()).getString();
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("RUN_KEY",new StringT(RunKey)));
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("CONFIGURED_WITH_RUN_KEY",new StringT(RunKey)));
-        }
-        else {
-          String warnMessage = "[HCAL LVL2 " + functionManager.FMname + "] Did not receive a run key.\nThis is probably OK for normal HCAL LVL2 operations ...";
-          logger.warn(warnMessage);
-        }
-
-        // get the tpg key from the configure command
-        if (parameterSet.get("TPG_KEY") != null) {
-          TpgKey = ((StringT)parameterSet.get("TPG_KEY").getValue()).getString();
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("CONFIGURED_WITH_TPG_KEY",new StringT(TpgKey)));
-          String warnMessage = "[HCAL LVL2 " + functionManager.FMname + "] Received a L1 TPG key: " + TpgKey;
-          logger.warn(warnMessage);
-        }
-        else {
-          String warnMessage = "[HCAL LVL2 " + functionManager.FMname + "] Did not receive a L1 TPG key.\nThis is only OK for HCAL local run operations ...";
-          logger.warn(warnMessage);
-        }
+        // Check and receive TPG key
+        CheckAndSetParameter(       parameterSet, "TPG_KEY" );
+        CheckAndSetTargetParameter( parameterSet, "TPG_KEY" ,"CONFIGURED_WITH_TPG_KEY",true);
 
         // get the info from the LVL1 if special actions due to a central CMS clock source change are indicated
         ClockChanged = false;
@@ -503,36 +478,19 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         }
 
         UseResetForRecover = true;
-        if (parameterSet.get("USE_RESET_FOR_RECOVER") != null) {
-          UseResetForRecover = ((BooleanT)parameterSet.get("USE_RESET_FOR_RECOVER").getValue()).getBoolean();
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<BooleanT>("USE_RESET_FOR_RECOVER", new BooleanT(UseResetForRecover)));
-        }
+        CheckAndSetParameter( parameterSet, "USE_RESET_FOR_RECOVER");
 
         UsePrimaryTCDS = true;
-        if (parameterSet.get("USE_PRIMARY_TCDS") != null) {
-          UsePrimaryTCDS=((BooleanT)parameterSet.get("USE_PRIMARY_TCDS").getValue()).getBoolean();
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<BooleanT>("USE_PRIMARY_TCDS", new BooleanT(UsePrimaryTCDS)));
-        }
+        CheckAndSetParameter( parameterSet, "USE_PRIMARY_TCDS");
 
         // get the supervisor error from the lvl1 
         SupervisorError = "not set";
-        if (parameterSet.get("SUPERVISOR_ERROR") != null) {
-          SupervisorError = ((StringT)parameterSet.get("SUPERVISOR_ERROR").getValue()).getString();
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("SUPERVISOR_ERROR", new StringT(SupervisorError)));
-        }
+        CheckAndSetParameter( parameterSet, "SUPERVISOR_ERROR");
 
         // get the FED list from the configure command in global run
-        if (parameterSet.get("FED_ENABLE_MASK") != null) {
-          FedEnableMask = ((StringT)parameterSet.get("FED_ENABLE_MASK").getValue()).getString();
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("FED_ENABLE_MASK",new StringT(FedEnableMask)));
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("CONFIGURED_WITH_FED_ENABLE_MASK",new StringT(FedEnableMask)));
-          functionManager.HCALFedList = getEnabledHCALFeds(FedEnableMask);
+        CheckAndSetParameter(       parameterSet, "FED_ENABLE_MASK");
+        CheckAndSetTargetParameter( parameterSet, "FED_ENABLE_MASK" ,"CONFIGURED_WITH_FED_ENABLE_MASK",true);
 
-          logger.info("[HCAL LVL2 " + functionManager.FMname + "] ... did receive a FED list during the configureAction(). Here it is:\n "+ FedEnableMask);
-        }
-        else {
-          logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Did not receive a FED list during the configureAction() - this is bad!");
-        }
 
         // get the HCAL CfgCVSBasePath from LVL1 if the LVL1 has sent something
         try{

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -511,33 +511,18 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       CfgCVSBasePath           = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGCVSBASEPATH").getValue()).getString();
       // Reset HCAL_CFGSCRIPT:
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("HCAL_CFGSCRIPT",new StringT("not set")));
-      // Try to find a common masterSnippet from MasterSnippet
-      String CommonMasterSnippetFile ="";
+      // Parse MasterSnippet
       try{
-        String TagName="CommonMasterSnippet";
-        String attribute="file";
-        CommonMasterSnippetFile = xmlHandler.getHCALMasterSnippetTagAttribute(selectedRun,CfgCVSBasePath,TagName,attribute);
+        //Parse common+main mastersnippet to pick up all-partition settings
+        xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath,"");
+        //Parse common+main mastersnippet for partition specific settings
+        xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath,functionManager.FMpartition);
       }
       catch(UserActionException e){
-        logger.error("[HCAL LVL2"+functionManager.FMname+"]: Found more than one CommonMasterSnippet tag in the mastersnippet! This is not allowed!");
-        functionManager.goToError(e.getMessage());
+        String errMessage = "[HCAL LVL2"+functionManager.FMname+"]: Failed to parse mastersnippets:";
+        functionManager.goToError(errMessage,e);
+        return;
       }
-      if(!CommonMasterSnippetFile.equals("")){    
-          //parse and set HCAL parameters from CommonMasterSnippet
-          logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet : "+ CommonMasterSnippetFile);
-          xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath);
-      }
-      //Parse and set HCAL parameters from MasterSnippet
-      logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse MasterSnippet : "+ selectedRun);
-      xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath);
-
-      if(!CommonMasterSnippetFile.equals("")){    
-          //parse and set HCAL parameters from CommonMasterSnippet
-          logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse CommonMasterSnippet(partition specific) : "+ CommonMasterSnippetFile);
-          xmlHandler.parseMasterSnippet(CommonMasterSnippetFile,CfgCVSBasePath,functionManager.FMpartition);
-      }
-      logger.info("[HCAL LVL2 "+ functionManager.FMname +"] Going to parse MasterSnippet(partition specific): "+ selectedRun);
-      xmlHandler.parseMasterSnippet(selectedRun,CfgCVSBasePath,functionManager.FMpartition);
 
       //Append CfgScript from runkey (if any)
       StringT runkeyName                 = (StringT) functionManager.getHCALparameterSet().get("CFGSNIPPET_KEY_SELECTED").getValue();

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -266,15 +266,11 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         functionManager.parameterSender.start();
       }
 
-  
-      if (parameterSet.get("RUN_CONFIG_SELECTED") != null) {
-        String RunConfigSelected = ((StringT)parameterSet.get("RUN_CONFIG_SELECTED").getValue()).getString();
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("RUN_CONFIG_SELECTED",new StringT(RunConfigSelected)));
-      }
-      else {
-        String warnMessage = "[HCAL LVL2 " + functionManager.FMname + "] Did not receive the user-selected CfgSnippet key.";
-        logger.warn(warnMessage);
-      }
+
+      //Receive selected runkey name, mastersnippet file name, runkey map from LV1 
+      CheckAndSetParameter( parameterSet, "RUN_CONFIG_SELECTED");
+      CheckAndSetParameter( parameterSet, "CFGSNIPPET_KEY_SELECTED");
+      CheckAndSetParameter( parameterSet, "AVAILABLE_RUN_CONFIGS");
       // give the RunType to the controlling FM
       functionManager.RunType = RunType;
       logger.info("[HCAL LVL2 " + functionManager.FMname + "] initAction: We are in " + RunType + " mode ...");

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -412,9 +412,13 @@ public class HCALxmlHandler {
     }
     return tmpAttribute;
   }
-
   // Fill parameters from MasterSnippet
   public void parseMasterSnippet(String selectedRun, String CfgCVSBasePath) throws UserActionException{
+      parseMasterSnippet(selectedRun, CfgCVSBasePath, "") ;
+  }
+
+  // Fill parameters from MasterSnippet
+  public void parseMasterSnippet(String selectedRun, String CfgCVSBasePath,String PartitionName) throws UserActionException{
     try{
         // Get ControlSequences from mastersnippet
         docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
@@ -429,14 +433,28 @@ public class HCALxmlHandler {
             Element iElement = (Element) listOfTags.item(i);
             String  iTagName = iElement.getNodeName();
             Boolean isValidTag = Arrays.asList(ValidMasterSnippetTags).contains( iTagName );
-            logger.info("[HCAL "+functionManager.FMname+" ] parseMasterSnippet: Found TagName = "+ iTagName );
-
+            
             if(isValidTag){
               if (iTagName == "FMParameter") {
                 SetHCALFMParameter(iElement);
               } else {
-                NodeList iNodeList = masterSnippetElement.getElementsByTagName( iTagName ); 
-                SetHCALParameterFromTagName( iTagName , iNodeList, CfgCVSBasePath);
+                //Parse all parameters if no PartitionName is specified
+                if(PartitionName==""){
+                  logger.info("[HCAL "+functionManager.FMname+" ] parseMasterSnippet: parsing TagName = "+ iTagName );
+                  NodeList iNodeList = masterSnippetElement.getElementsByTagName( iTagName ); 
+                  SetHCALParameterFromTagName( iTagName , iNodeList, CfgCVSBasePath);
+                }
+                else{
+                  //Parse only the parameters matching to PartitionName 
+                  if(iElement.hasAttribute("Partition") && PartitionName == iElement.getAttributes().getNamedItem("Partition").getNodeValue()){
+                    logger.info("[HCAL "+functionManager.FMname+" ] parseMasterSnippet: parsing TagName = "+ iTagName );
+                    NodeList iNodeList = masterSnippetElement.getElementsByTagName( iTagName ); 
+                    SetHCALParameterFromTagName( iTagName , iNodeList, CfgCVSBasePath);
+                  }
+                  else{
+                    logger.info("[HCAL "+functionManager.FMname+" ] parseMasterSnippet: skipping TagName = "+ iTagName );
+                  }
+                }
               }
             }
           }

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -462,6 +462,7 @@ public class HCALxmlHandler {
           for (QualifiedResource FMqr: allFMlists){
             // FM name = HCAL_PartitionName
             ValidPartitionNames.add(FMqr.getName().substring(5));
+            ValidPartitionNames.add(FMqr.getName());
           }
 
           for(int i =0;i< listOfTags.getLength();i++){

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -428,6 +428,27 @@ public class HCALxmlHandler {
         Element masterSnippetElement = masterSnippet.getDocumentElement();
 
         NodeList listOfTags = masterSnippetElement.getChildNodes();
+        String commonMasterSnippetFile = "";
+        for(int i =0;i< listOfTags.getLength();i++){
+          if( listOfTags.item(i).getNodeType()== Node.ELEMENT_NODE){
+            if (listOfTags.item(i).getNodeName() == "CommonMasterSnippet") {
+              if (commonMasterSnippetFile != "") {
+                String errMessage = "[HCAL " + functionManager.FMname + "] parseMasterSnippet: Found multiple instances of CommonMasterSnippet. Only one is allowed.";
+                throw new UserActionException(errMessage);
+              }
+              commonMasterSnippetFile = ((Element)listOfTags.item(i)).getAttributes().getNamedItem("file").getNodeValue();
+            }
+          }
+        }
+        if (commonMasterSnippetFile != "") {
+          if(PartitionName==""){
+            logger.info("[HCAL " + functionManager.FMname + "]: Parsing the common master snippet from " + commonMasterSnippetFile + ".");
+          }else{
+            logger.info("[HCAL " + functionManager.FMname + "]: Parsing the common master snippet for partition "+PartitionName+" from " + commonMasterSnippetFile + ".");
+          }
+          this.parseMasterSnippet(commonMasterSnippetFile,CfgCVSBasePath,PartitionName);
+        }
+
         for(int i =0;i< listOfTags.getLength();i++){
           if( listOfTags.item(i).getNodeType()== Node.ELEMENT_NODE){
             Element iElement = (Element) listOfTags.item(i);

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -420,6 +420,7 @@ public class HCALxmlHandler {
   // Fill parameters from MasterSnippet
   public void parseMasterSnippet(String selectedRun, String CfgCVSBasePath,String PartitionName) throws UserActionException{
     try{
+        logger.info("[HCAL " + functionManager.FMname + "]: Welcome to parseMasterSnippet. Mastersnippet file=" + selectedRun + "; PartitionName= "+PartitionName);
         // Get ControlSequences from mastersnippet
         docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
         Document masterSnippet = docBuilder.parse(new File(CfgCVSBasePath + selectedRun + "/pro"));
@@ -444,9 +445,10 @@ public class HCALxmlHandler {
           if(PartitionName==""){
             logger.info("[HCAL " + functionManager.FMname + "]: Parsing the common master snippet from " + commonMasterSnippetFile + ".");
           }else{
-            logger.info("[HCAL " + functionManager.FMname + "]: Parsing the common master snippet for partition "+PartitionName+" from " + commonMasterSnippetFile + ".");
+            logger.info("[HCAL " + functionManager.FMname + "]: Parsing the common master snippet from " + commonMasterSnippetFile + " for Partition="+PartitionName+" .");
           }
           this.parseMasterSnippet(commonMasterSnippetFile,CfgCVSBasePath,PartitionName);
+          logger.info("[HCAL " + functionManager.FMname + "]: Done parsing the common mastersnippet. Continue to parse the main one.");
         }
 
         for(int i =0;i< listOfTags.getLength();i++){

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -466,10 +466,12 @@ public class HCALxmlHandler {
                   logger.info("[HCAL "+functionManager.FMname+" ] removing this node:"+ iElement.getNodeName()+" because it is not partition specific.");
                }
                //Remove the partition elements that are for other partitions
-               if(iElement.hasAttribute("Partition") && !PartitionName.equals(iElement.getAttributes().getNamedItem("Partition").getNodeValue())){
+               if(iElement.hasAttribute("Partition")){
                   String ElementPartition = iElement.getAttributes().getNamedItem("Partition").getNodeValue();
-                  iElement.getParentNode().removeChild(iElement);
-                  logger.info("[HCAL "+functionManager.FMname+" ] removing this node:"+ iElement.getNodeName()+" because "+PartitionName+" is not "+ElementPartition);
+                  if(!ElementPartition.contains(PartitionName)){
+                    iElement.getParentNode().removeChild(iElement);
+                    logger.info("[HCAL "+functionManager.FMname+" ] removing this node:"+ iElement.getNodeName()+" because "+ElementPartition+" do not contain "+PartitionName);
+                  }
                }
             }
           }

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -474,9 +474,13 @@ public class HCALxmlHandler {
                 String[] ElementPartitionArray = ElementPartition.split(";");
                 for(String partitionName:ElementPartitionArray){
                   if(! ValidPartitionNames.contains(partitionName)){
-                    String errMessage = "[HCAL"+functionManager.FMname+"] parseMasterSnippet: Found invalid PartitionName="+partitionName+" in this tag "+ElementName+".\n Valid partition names are:"+ ValidPartitionNames.toString();
+                    String errMessage = "[HCAL"+functionManager.FMname+"] parseMasterSnippet: Found invalid Partition="+partitionName+" in this tag "+ElementName+".\n Valid partition names are:"+ ValidPartitionNames.toString();
                     functionManager.goToError(errMessage);
                   }
+                }
+                if(ElementName.equals("CfgScript")){
+                    String errMessage = "[HCAL"+functionManager.FMname+"] parseMasterSnippet: Found Partition attribute in CfgScript. This is not allowed. Please try to set the same partition-specific setting via snippet." ;
+                    functionManager.goToError(errMessage);
                 }
               }
             }


### PR DESCRIPTION
Implements #285. 
Partition-specific FM parameters can be set by adding an attribute like `Partition=Laser` to the element in the xml.
Instead of having LV1 reads MS and passes the results to the LV2s, LV2s will read MS and pick up the attribute specific to its partition if there are any. 
The partition specific values (if any) will naturally override the settings directing to all partitions. 
The partition specific values can live in both commonMS and main MS. Same MS-overrides-commonMS rule applies to them.  
Example usage for HO's resync Bgo will look like this:
 ```
<ICIControlMulti>
  <include file="/TCDS/BGo_global.cfg" version="pro"/>
  <include file="/TCDS/global.cfg" version="pro"/>
  <include file="/TCDS/brildaq.cfg" version="pro"/>
  <!-- <include file="/TCDS/BGo_PedOnly_CalibSequence.cfg" version="pro"/>-->
  <!-- <include file="/TCDS/BGo_LaserOnly_CalibSequence.cfg" version="pro"/> -->
  <include file="/TCDS/BGo_CalibSequence.cfg" version="pro"/> 
</ICIControlMulti>
<ICIControlMulti Partition="HO">
  <include file="/TCDS/BGo_HO_resync.cfg" version="pro"/>
  <include file="/TCDS/BGo_global.cfg" version="pro"/>
  <include file="/TCDS/global.cfg" version="pro"/>
  <include file="/TCDS/BGo_PedOnly_CalibSequence.cfg" version="pro"/> 
  <!-- <include file="/TCDS/BGo_LaserOnly_CalibSequence.cfg" version="pro"/>-->
  <!-- <include file="/TCDS/BGo_CalibSequence.cfg" version="pro"/> -->
</ICIControlMulti>
```
This change is back-ward compatible to current mastersnippets.
RunkeyCfg (aka CfgToAppend) is also parsed by LV2, although cannot be made partition-specific as is.