### PR TITLE
ConfigPriority

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -59,6 +59,7 @@ import rcms.fm.resource.qualifiedresource.JobControl;
 import rcms.fm.resource.qualifiedresource.FunctionManager;
 import rcms.resourceservice.db.Group;
 import rcms.resourceservice.db.resource.Resource;
+import rcms.resourceservice.db.resource.config.ConfigProperty;
 import rcms.resourceservice.db.resource.fm.FunctionManagerResource;
 import rcms.resourceservice.db.resource.xdaq.XdaqApplicationResource;
 import rcms.resourceservice.db.resource.xdaq.XdaqExecutiveResource;
@@ -2750,5 +2751,25 @@ public class HCALEventHandler extends UserEventHandler {
         qr.setInitialized(true);
       }
     }
-  } 
+  }
+
+  // Get property from a QR
+  public String getProperty(QualifiedResource QR,  String name ) throws Exception {
+
+    List<ConfigProperty> propertiesList = QR.getResource().getProperties();
+
+    if(propertiesList.isEmpty()) {
+      throw new Exception("Property list is empty");
+    }
+    ConfigProperty property = null;
+    Iterator<ConfigProperty> iter = propertiesList.iterator();
+    while(iter.hasNext()) {
+      property = iter.next();
+      if(property.getName().equals(name)) {
+        return property.getValue();
+      }
+    }
+    throw new Exception("Property "+name+" not found");
+  }
+
 }

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2667,6 +2667,12 @@ public class HCALEventHandler extends UserEventHandler {
       throw new UserActionException(errMessage);
     }
   }
+  // Print of the names of the QR in an arrayList
+  void PrintQRnames(List<QualifiedResource> qrlist){
+    QualifiedResourceContainer qrc = new QualifiedResourceContainer(qrlist);
+    PrintQRnames(qrc);
+  }
+
   // Print of the names of the QR in a QRContainer 
   void PrintQRnames(QualifiedResourceContainer qrc){
     String Names = "";

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -688,6 +688,8 @@ public class HCALEventHandler extends UserEventHandler {
 
     functionManager.containerFMEvmTrig = new QualifiedResourceContainer(qg.seekQualifiedResourcesOfRole("EvmTrig"));
     functionManager.containerFMTCDSLPM = new QualifiedResourceContainer(qg.seekQualifiedResourcesOfRole("Level2_TCDSLPM"));
+    //Empty the container if LPM FM is masked
+    functionManager.containerFMTCDSLPM = new QualifiedResourceContainer(functionManager.containerFMTCDSLPM.getActiveQRList());
     ActiveChildFMs.removeAll(qg.seekQualifiedResourcesOfRole("EvmTrig"));
     ActiveChildFMs.removeAll(qg.seekQualifiedResourcesOfRole("Level2_TCDSLPM"));
 

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -3,6 +3,7 @@ package rcms.fm.app.level1;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Arrays;
 import java.util.ArrayList;
 
@@ -15,6 +16,7 @@ import rcms.resourceservice.db.resource.xdaq.XdaqApplicationResource;
 import rcms.resourceservice.db.resource.xdaq.XdaqExecutiveResource;
 import rcms.fm.resource.QualifiedGroup;
 import rcms.fm.resource.QualifiedResource;
+import rcms.fm.resource.QualifiedResourceContainer;
 import rcms.fm.resource.qualifiedresource.FunctionManager;
 import rcms.fm.fw.parameter.type.StringT;
 import rcms.fm.fw.parameter.type.VectorT;
@@ -155,12 +157,27 @@ public class HCALMasker {
     VectorT<StringT> MaskedFMs =  (VectorT<StringT>)functionManager.getHCALparameterSet().get("MASKED_RESOURCES").getValue();
 
     List<QualifiedResource> level2list = qg.seekQualifiedResourcesOfType(new FunctionManager());
-
+    List<QualifiedResource> level2noMaskedFMlist=new ArrayList<QualifiedResource>() ;
+    //Ignore masked FMs
     for (QualifiedResource level2 : level2list) {
-      //logger.warn("[JohnLogMaskBug] " + functionManager.FMname + ": now checking if " + level2.getName() + " is masked before picking the EvmTrig FM. The list of masked FMs is:");
-      //logger.warn(Arrays.asList(MaskedFMs.toArray()).toString());
       if (!Arrays.asList(MaskedFMs.toArray()).contains(new StringT(level2.getName()))) {
-        //logger.warn("[JohnLogMaskBug] " + functionManager.FMname + "... didn't find " + level2.getName() + " in the masked FMs list.");
+        level2noMaskedFMlist.add(level2);
+      }
+    }
+    QualifiedResourceContainer level2QRC = new QualifiedResourceContainer(level2noMaskedFMlist);
+
+    //Get ConfigPriority map of active FMs
+    TreeMap<Integer, ArrayList<FunctionManager> > priorityFMmap = ((HCALlevelOneEventHandler)functionManager.theEventHandler).getConfigPriorities(level2QRC);
+    Integer  LastPriority = priorityFMmap.lastKey();
+    List<QualifiedResource> level2EvmTrigCandidateList = new ArrayList<QualifiedResource>();
+
+    //Add last priority FMs into evmTrigCandidateList
+    level2EvmTrigCandidateList.addAll(priorityFMmap.get(LastPriority));
+    logger.info("[HCAL "+functionManager.FMname+"] Considering following FMs to be EvmTrig:");
+    functionManager.theEventHandler.PrintQRnames(level2EvmTrigCandidateList);
+
+    //Consider only LV2 FMs with last priority to be EvmTrig (FM with no ConfigPriority will be grouped into this)
+    for (QualifiedResource level2 : level2EvmTrigCandidateList) {
         try {
           QualifiedGroup level2group = ((FunctionManager)level2).getQualifiedGroup();
           logger.debug("[HCAL " + functionManager.FMname + "]: the qualified group has this DB connector" + level2group.rs.toString());
@@ -210,7 +227,6 @@ public class HCALMasker {
         catch (DBConnectorException ex) {
           logger.error("[HCAL " + functionManager.FMname + "]: Got a DBConnectorException when trying to retrieve level2s' children resources: " + ex.getMessage());
         }
-      }
     }
 
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -993,30 +993,18 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         if (!functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM.isEmpty()){
 
           //List of distinct list of configPriorities from LV2 properties
-          Map<Integer, ArrayList<String> > priorityFMmap= getConfigPriorities(functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM);
+          Map<Integer, ArrayList<FunctionManager> > priorityFMmap= getConfigPriorities(functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM);
 
-          for (Map.Entry<Integer, ArrayList<String> > entry: priorityFMmap.entrySet()){
-            Integer      thisPriority = entry.getKey();
-            ArrayList<String> FMnames = entry.getValue();
+          for (Map.Entry<Integer, ArrayList<FunctionManager> > entry: priorityFMmap.entrySet()){
+            Integer                        thisPriority = entry.getKey();
+            ArrayList<FunctionManager> thisPriorityFMs  = entry.getValue();
           
-            //Add all FMs with thisPriority to a QRCcontainer
-            List<FunctionManager> thisPriorityFMs = new ArrayList<FunctionManager>();
-            for(QualifiedResource normalFMqr : functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM.getQualifiedResourceList()){
-              if(FMnames.contains(normalFMqr.getName())){
-                FunctionManager normalFM = (FunctionManager) normalFMqr;
-                thisPriorityFMs.add(normalFM);
-              }
-            }
             logger.info("[HCAL LVL1 " + functionManager.FMname +"] configPriority ="+thisPriority+" has the following FMs");
             QualifiedResourceContainer thisPriorityFMContainer = new QualifiedResourceContainer(thisPriorityFMs);
             PrintQRnames(thisPriorityFMContainer);
             SimpleTask thisPriorityTask   = new SimpleTask(thisPriorityFMContainer,configureInput,HCALStates.CONFIGURING,HCALStates.CONFIGURED,"LV1: Configuring normalFMs with priority"+thisPriority);
             configureTaskSeq.addLast(thisPriorityTask);
           }
-          //SimpleTask fmChildrenTask   = new SimpleTask(functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM,configureInput,HCALStates.CONFIGURING,HCALStates.CONFIGURED,"LV1: Configuring regular priority FM children");
-          //logger.info("[HCAL LVL1 " + functionManager.FMname +"] Configuring these regular LV2 FMs: ");
-          //PrintQRnames(functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM);
-          //configureTaskSeq.addLast(fmChildrenTask);
         }
         // 3) configure EvmTrig FM last 
         // NOTE: Emptyness check is important to support global run
@@ -1783,34 +1771,34 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
  }
  
  //Get sorted Map of ConfigPriority (1:FM1,FM2, 2:FM3,FM4) from the LV2FMs
- public Map<Integer, ArrayList<String> > getConfigPriorities(QualifiedResourceContainer LV2FMs){
+ public Map<Integer, ArrayList<FunctionManager> > getConfigPriorities(QualifiedResourceContainer LV2FMs){
   //TreeMap by default sorts accending order with keys
-  Map<Integer, ArrayList<String> > configPriorityMap  = new TreeMap<Integer, ArrayList<String> >();
+  Map<Integer, ArrayList<FunctionManager> > configPriorityMap  = new TreeMap<Integer, ArrayList<FunctionManager> >();
   Set<Integer> configMapKeys = configPriorityMap.keySet();
   Integer defaultPriority = 99;
-  configPriorityMap.put(defaultPriority,new ArrayList<String>());
+  configPriorityMap.put(defaultPriority,new ArrayList<FunctionManager>());
   for(QualifiedResource LV2FM : LV2FMs.getQualifiedResourceList()){
     try{
       Integer thisConfigPriority = Integer.parseInt(getProperty(LV2FM,"configPriority"));
       if (!configMapKeys.contains(thisConfigPriority)){
         //New configPriority,
-        ArrayList<String> FMnames = new ArrayList<String>();
-        FMnames.add(LV2FM.getName());
-        configPriorityMap.put(thisConfigPriority,FMnames);
+        ArrayList<FunctionManager> FMlist = new ArrayList<FunctionManager>();
+        FMlist.add((FunctionManager) LV2FM);
+        configPriorityMap.put(thisConfigPriority,FMlist);
       }else{
         //Existing configPriority, append FM name to this priority
-        ArrayList<String> FMnames = configPriorityMap.get(thisConfigPriority);
-        FMnames.add(LV2FM.getName());
-        configPriorityMap.put(thisConfigPriority,FMnames);
+        ArrayList<FunctionManager> FMlist = configPriorityMap.get(thisConfigPriority);
+        FMlist.add((FunctionManager) LV2FM);
+        configPriorityMap.put(thisConfigPriority,FMlist);
       }
     }
     catch(Exception e){
-      ArrayList<String> FMnames = configPriorityMap.get(defaultPriority);
-      FMnames.add(LV2FM.getName());
-      configPriorityMap.put(defaultPriority,FMnames);
+      ArrayList<FunctionManager> FMlist = configPriorityMap.get(defaultPriority);
+      FMlist.add((FunctionManager) LV2FM);
+      configPriorityMap.put(defaultPriority,FMlist);
     }
   }
-  logger.info("[HCAL "+functionManager.FMname +"] Map of configPriorities="+configPriorityMap.toString());
+  //logger.info("[HCAL "+functionManager.FMname +"] Map of configPriorities="+configPriorityMap.toString());
   return configPriorityMap;
  }
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -39,7 +39,6 @@ import rcms.resourceservice.db.resource.config.ConfigProperty;
 import rcms.stateFormat.StateNotification;
 import rcms.util.logger.RCMSLogger;
 import rcms.utilities.fm.task.SimpleTask;
-import rcms.utilities.fm.task.CompositeTask;
 import rcms.utilities.fm.task.TaskSequence;
 import rcms.utilities.runinfo.RunNumberData;
 import rcms.statemachine.definition.Input;
@@ -996,7 +995,6 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           //List of distinct list of configPriorities from LV2 properties
           Map<Integer, ArrayList<String> > priorityFMmap= getConfigPriorities(functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM);
 
-          CompositeTask normalFMtasks = new CompositeTask();
           for (Map.Entry<Integer, ArrayList<String> > entry: priorityFMmap.entrySet()){
             Integer      thisPriority = entry.getKey();
             ArrayList<String> FMnames = entry.getValue();
@@ -1013,13 +1011,12 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
             QualifiedResourceContainer thisPriorityFMContainer = new QualifiedResourceContainer(thisPriorityFMs);
             PrintQRnames(thisPriorityFMContainer);
             SimpleTask thisPriorityTask   = new SimpleTask(thisPriorityFMContainer,configureInput,HCALStates.CONFIGURING,HCALStates.CONFIGURED,"LV1: Configuring normalFMs with priority"+thisPriority);
-            normalFMtasks.addTask(thisPriorityTask);
+            configureTaskSeq.addLast(thisPriorityTask);
           }
           //SimpleTask fmChildrenTask   = new SimpleTask(functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM,configureInput,HCALStates.CONFIGURING,HCALStates.CONFIGURED,"LV1: Configuring regular priority FM children");
           //logger.info("[HCAL LVL1 " + functionManager.FMname +"] Configuring these regular LV2 FMs: ");
           //PrintQRnames(functionManager.containerFMChildrenNoEvmTrigNoTCDSLPM);
           //configureTaskSeq.addLast(fmChildrenTask);
-          configureTaskSeq.addLast(normalFMtasks);
         }
         // 3) configure EvmTrig FM last 
         // NOTE: Emptyness check is important to support global run


### PR DESCRIPTION
Implements #357. 
There are two parts in the use of `configPriority`:
 - In `PickEvmTrig`, only the last configPriority will be considered as EvmTrig FM.
 - LV1 prioritises the rest of the FMs according to the configPriority 

The configPriority is taken from the property of LV2 FMs. The example for P5 operation would be:
```
HBHEc, HF,HO    - int configPriority 1 
HBHEa,b, Laser  - int configPriority 2 
```
The input will be used to fill the task sequences for configuration 
```
TaskSequence   configTask
// SimpleTask      1) LPM FM
// N SimpleTasks   2) Normal FMs, for N different configPriority
// SimpleTask      3) configure EvmTrig FM last
```
Some details on the implementation:
 - partitions with no `configPriority` property, will be grouped into the last of the priority 
 - partitions with same priority will be configured in parallel. 