### PR TITLE
change naming convention in xmlHandler

### DIFF
--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -174,7 +174,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       String MasterSnippetList = ((StringT) functionManager.getHCALparameterSet().get("HCAL_MASTERSNIPPETLIST").getValue()).getString();
 
       if(MasterSnippetList!=""){
-        NodeList nodes = xmlHandler.getHCALuserXML(CfgCVSBasePath,MasterSnippetList).getElementsByTagName("RunConfig");
+        NodeList nodes = xmlHandler.getHCALgrandmaster(CfgCVSBasePath,MasterSnippetList).getElementsByTagName("RunConfig");
         for (int i=0; i < nodes.getLength(); i++) {
           //logger.debug("[HCAL " + functionManager.FMname + "]: Item " + i + " has node name: " + nodes.item(i).getAttributes().getNamedItem("name").getNodeValue() 
           //    + ", snippet name: " + nodes.item(i).getAttributes().getNamedItem("snippet").getNodeValue()+ ", and maskedapps: " + nodes.item(i).getAttributes().getNamedItem("maskedapps").getNodeValue());
@@ -307,14 +307,14 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         try {
           if (functionManager.FMrole.equals("HCAL")) {
             CfgSnippetKeySelected = "global_HCAL";
-            RunConfigSelected = xmlHandler.getNamedUserXMLelementAttributeValue("RunConfig", CfgSnippetKeySelected, "snippet",true);
+            RunConfigSelected = xmlHandler.getNamedXMLelementAttributeValue("RunConfig", CfgSnippetKeySelected, "snippet",true);
             logger.warn("[JohnLog3] " + functionManager.FMname + ": This level1 with role " + functionManager.FMrole + " thinks we are in global mode and thus picked the RunConfigSelected = " + RunConfigSelected );
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("RUN_CONFIG_SELECTED",new StringT(RunConfigSelected)));
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("CFGSNIPPET_KEY_SELECTED",new StringT(CfgSnippetKeySelected)));
           }
           else if (functionManager.FMrole.equals("HF")) {
             CfgSnippetKeySelected = "global_HF";
-            RunConfigSelected = xmlHandler.getNamedUserXMLelementAttributeValue("RunConfig", CfgSnippetKeySelected, "snippet",true);
+            RunConfigSelected = xmlHandler.getNamedXMLelementAttributeValue("RunConfig", CfgSnippetKeySelected, "snippet",true);
             logger.warn("[JohnLog3] " + functionManager.FMname + ": This level1 with role " + functionManager.FMrole + " thinks we are in global mode and thus picked the RunConfigSelected = " + RunConfigSelected );
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("RUN_CONFIG_SELECTED",new StringT(RunConfigSelected)));
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("CFGSNIPPET_KEY_SELECTED",new StringT(CfgSnippetKeySelected)));

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -99,7 +99,7 @@ public class HCALxmlHandler {
   }
 
   // Get userXML from a CfgCVS path
-  public Element getHCALuserXML(String CfgCVSBasePath,String fileName) throws UserActionException {
+  public Element getHCALgrandmaster(String CfgCVSBasePath,String fileName) throws UserActionException {
     try {
       // return the userXML
       File grandMaster = new File(CfgCVSBasePath+fileName+"/pro");
@@ -130,25 +130,25 @@ public class HCALxmlHandler {
   public String getHCALuserXMLelementContent(String tagName,Boolean isGrandMaster) throws UserActionException {
       String CfgCVSBasePath    = ((StringT) functionManager.getHCALparameterSet().get("HCAL_CFGCVSBASEPATH").getValue()).getString();
       String MasterSnippetList = ((StringT) functionManager.getHCALparameterSet().get("HCAL_MASTERSNIPPETLIST").getValue()).getString();
-      Element hcalUserXML = null;
+      Element hcalXML = null;
     try {
       if (!isGrandMaster){
-        hcalUserXML = getHCALuserXML();
+        hcalXML = getHCALuserXML();
       }
       else{
-        hcalUserXML = getHCALuserXML(CfgCVSBasePath,MasterSnippetList);
+        hcalXML = getHCALgrandmaster(CfgCVSBasePath,MasterSnippetList);
       }
     }
     catch(UserActionException e){
       throw e;
     }
     try{
-      if (!hcalUserXML.equals(null) && !hcalUserXML.getElementsByTagName(tagName).equals(null)) {
-        if (hcalUserXML.getElementsByTagName(tagName).getLength()==1) {
-          return hcalUserXML.getElementsByTagName(tagName).item(0).getTextContent();
+      if (!hcalXML.equals(null) && !hcalXML.getElementsByTagName(tagName).equals(null)) {
+        if (hcalXML.getElementsByTagName(tagName).getLength()==1) {
+          return hcalXML.getElementsByTagName(tagName).item(0).getTextContent();
         }
         else {
-          String errMessage = (hcalUserXML.getElementsByTagName(tagName).getLength()==0) ? " was not found in the userXML. Will use value supplied by level1 or default value." : " was found with more than one occurrance in the userXML.";
+          String errMessage = (hcalXML.getElementsByTagName(tagName).getLength()==0) ? " was not found in the userXML. Will use value supplied by level1 or default value." : " was found with more than one occurrance in the userXML.";
           throw new UserActionException("[HCAL " + functionManager.FMname + "]: The userXML element with tag name '" + tagName + "'" + errMessage);
         }
       }
@@ -157,21 +157,21 @@ public class HCALxmlHandler {
     catch (UserActionException e) {throw e;}
   }
 
-  public String getNamedUserXMLelementAttributeValue (String tag, String name, String attribute, Boolean isGrandMaster ) throws UserActionException {
+  public String getNamedXMLelementAttributeValue (String tag, String name, String attribute, Boolean isGrandMaster ) throws UserActionException {
     try {
       boolean foundTheRequestedNamedElement = false;
       String CfgCVSBasePath    = ((StringT) functionManager.getHCALparameterSet().get("HCAL_CFGCVSBASEPATH").getValue()).getString();
       String MasterSnippetList = ((StringT) functionManager.getHCALparameterSet().get("HCAL_MASTERSNIPPETLIST").getValue()).getString();
-      Element hcalUserXML=null;
+      Element hcalXML=null;
       if (!isGrandMaster){
-        hcalUserXML = getHCALuserXML();
+        hcalXML = getHCALuserXML();
       }
       else{
-        hcalUserXML = getHCALuserXML(CfgCVSBasePath,MasterSnippetList);
+        hcalXML = getHCALgrandmaster(CfgCVSBasePath,MasterSnippetList);
       }
-      if (!hcalUserXML.equals(null) && !hcalUserXML.getElementsByTagName(tag).equals(null)) {
-        if (hcalUserXML.getElementsByTagName(tag).getLength()!=0) {
-          NodeList nodes = hcalUserXML.getElementsByTagName(tag); 
+      if (!hcalXML.equals(null) && !hcalXML.getElementsByTagName(tag).equals(null)) {
+        if (hcalXML.getElementsByTagName(tag).getLength()!=0) {
+          NodeList nodes = hcalXML.getElementsByTagName(tag); 
           logger.warn("[JohnLog3] " + functionManager.FMname + ": the length of the list of nodes with tag name '" + tag + "' is: " + nodes.getLength());
           for (int iNode = 0; iNode < nodes.getLength(); iNode++) {
             logger.warn("[JohnLog3] " + functionManager.FMname + " found a userXML element with tagname '" + tag + "' and name '" + ((Element)nodes.item(iNode)).getAttributes().getNamedItem("name").getNodeValue()  + "'"); 


### PR DESCRIPTION
This commit is meant to make the code more understandable; using the name "userXML" to refer to both the level1's "user XML" in the RS config as well as the grandmaster snippet is very confusing.

Please test.