### PR TITLE
cleanups

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -117,8 +117,8 @@ public class HCALEventHandler extends UserEventHandler {
   public Integer localeventstaken =  -1;          // TODO: what does this do?
   public String  GlobalConfKey    =  "";          // global configuration key
   public String  RunType          =  "";          // local or global
-  public String  RunKey           =  "";          // Current global run key
-  public String  CachedRunKey     =  "";          // Previous global run key
+  public String  GlobalRunkey           =  "";          // Current global run key
+  public String  CachedGlobalRunkey     =  "";          // Previous global run key
   public String  TpgKey           =  "";          // Current trigger key
   public String  CachedTpgKey     =  "";          // Previous trigger key
   public String  FedEnableMask    =  "";          // FED enable mask received from level0 on configure in global

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -953,11 +953,6 @@ public class HCALEventHandler extends UserEventHandler {
     }
   }
 
-  // method which returns a password free string
-  protected String PasswordFree(String Input) {
-    return Input.replaceAll("PASSWORD=[A-Za-z_0-9]+\"|PASSWORD=[A-Za-z_0-9]+,|OracleDBPassword=\"[A-Za-z_0-9]+\"","here_was_something_removed_because_of_security");
-  }
-
   // establish connection to RunInfoDB - if needed
   protected void checkRunInfoDBConnection() {
     if (functionManager.HCALRunInfo == null) {
@@ -1414,108 +1409,6 @@ public class HCALEventHandler extends UserEventHandler {
       }
     }
   }
-
-
-  // find out if all controlled EVMs are happy before stopping the run
-  protected boolean isRUBuildersEmpty() {
-    if (((FunctionManagerResource)functionManager.getQualifiedGroup().getGroup().getThisResource()).getRole().equals("EvmTrig")) {
-      logger.info("[HCAL " + functionManager.FMname + "] Checking if the RUs are empty ...");
-    }
-
-    boolean reply = true;
-
-    XdaqApplication evmApp = null;
-    Iterator evmIterator = functionManager.containerEVM.getQualifiedResourceList().iterator();
-    while (evmIterator.hasNext()) {
-      evmApp = (XdaqApplication) evmIterator.next();
-
-      try {
-        waitRUBuilderToEmpty(evmApp);
-      }
-      catch (Exception e) {
-        String errMessage = "[HCAL " + functionManager.FMname + "] Could not flush RUBuilder\nEVM URI: " + evmApp.getResource().getURI().toString();
-        logger.error(errMessage,e);
-        functionManager.sendCMSError(errMessage);
-        reply = false;
-      }
-    }
-    return reply;
-  }
-
-  // find out if one EVM is happy
-  private void waitRUBuilderToEmpty(XdaqApplication app) throws UserActionException {
-    if(app == null) { return; }
-    String nbEvtIdsValue;
-    String freeEvtIdsValue;
-    String freeEvtIdsInLastIteration;
-    String freeEvtIdsInFirstIteration;
-    XDAQParameter nbEvtIdsParm;
-    XDAQParameter freeEvtIdsParm;
-    int ntry = 0;
-
-    String nbEvtIdsInBuilderName = "nbEvtIdsInBuilder";
-    String freeEvtIdsName = "freeEventIdFIFOElements";
-    try {
-      nbEvtIdsParm = app.getXDAQParameter();
-      nbEvtIdsParm.select(nbEvtIdsInBuilderName);
-      nbEvtIdsValue = getValue(nbEvtIdsParm, nbEvtIdsInBuilderName);
-
-      freeEvtIdsParm = app.getXDAQParameter();
-      freeEvtIdsParm.select(freeEvtIdsName );
-      freeEvtIdsInLastIteration = getValue(freeEvtIdsParm,freeEvtIdsName);
-      freeEvtIdsInFirstIteration = freeEvtIdsInLastIteration;
-    }
-    catch (Exception e) {
-      String errMessage = "[HCAL " + functionManager.FMname + "] RUBuilder: exception occured while getting parameter ...";
-      logger.error(errMessage, e);
-      throw new UserActionException(errMessage,e);
-    }
-
-    while(true) {
-      try {
-        Thread.sleep(10000);
-      }
-      catch (Exception e) {
-        String errMessage = "[HCAL " + functionManager.FMname + "] Sleeping thread failed while waiting for the RU builder to flush!";
-        logger.error(errMessage, e);
-        throw new UserActionException(errMessage);
-      }
-      freeEvtIdsValue = getValue(freeEvtIdsParm,freeEvtIdsName);
-      if(nbEvtIdsValue.equals(freeEvtIdsValue)) {
-        break;
-      }
-
-      if(!freeEvtIdsInFirstIteration .equals(freeEvtIdsValue) && freeEvtIdsInLastIteration.equals(freeEvtIdsValue )) {
-        ntry++;
-        logger.info("[HCAL " + functionManager.FMname + "] Free IDs: " + freeEvtIdsValue);
-        if(ntry == 5) {
-          String errMessage = "[HCAL " + functionManager.FMname + "] EVM on URI " + app.getResource().getURI().toString() + " seems to have stopped building when not flushed.\nLast number of fre events Ids was: " + freeEvtIdsInLastIteration;
-          logger.error(errMessage);
-          throw new UserActionException(errMessage);
-        }
-      }
-      else {
-        ntry = 0;
-      }
-      freeEvtIdsInLastIteration = freeEvtIdsValue;
-    }
-  }
-
-  private String getValue(XDAQParameter param, String s) throws UserActionException {
-    try {
-      if(param.get()) {
-        return param.getValue(s);
-      }
-      else {
-        String errMessage = "[HCAL " + functionManager.FMname + "] Failed to get: "+ s;
-        throw new UserActionException(errMessage);
-      }
-    }
-    catch (Exception e) {
-      throw new UserActionException("[HCAL " + functionManager.FMname + "] Could not get value of: " + s,e);
-    }
-  }
-
 
   // checks if the TriggerAdapter is stopped
   protected Boolean isTriggerAdapterStopped() {

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -93,7 +93,6 @@ public class HCALEventHandler extends UserEventHandler {
 
 
 
-  String configString  = ""; // Configuration documents for hcos
   String ConfigDoc     = "";
   String FullCfgScript = "not set";
 
@@ -215,44 +214,6 @@ public class HCALEventHandler extends UserEventHandler {
     // Destroy the FM
     super.destroy();
   }
-
-  @SuppressWarnings("unchecked")
-    // Returns the embeded String of the User XML field
-    // If not found, an empty string is returned
-    // TODO kill this and make it look at the found mastersnippet xml
-    protected String GetUserXMLElement(String elementName) {
-
-      // Get the FM's resource configuration
-      String myConfig = configString;
-      logger.debug("[HCAL base] GetUserXMLElement: looking for element " + elementName + " in : " + myConfig );
-
-      // Get element value
-      String elementValue = getXmlRscConf(myConfig, elementName);
-
-      return elementValue;
-    }
-
-  // Returns the xml string of element "ElementName"
-  // If not found, an empty string is returned
-  // TODO remove custom XML parsing and replace with something non-idiotic
-  static private String getXmlRscConf(String xmlRscConf, String elementName) {
-    String response = "";
-
-    // Check if the xmlRscConf is filled
-    if (xmlRscConf == null || xmlRscConf.equals("") ) return response;
-
-    // Check for a valid argument
-    if (elementName == null || elementName.equals("") ) return response;
-
-    int beginIndex = xmlRscConf.indexOf("<"+elementName+">") + elementName.length() + 2;
-    int endIndex   = xmlRscConf.indexOf("</"+elementName+">");
-
-    // Check if the element is available in the userXML, and if so, get the info
-    if (beginIndex >= (elementName.length() + 2)) response = xmlRscConf.substring(beginIndex, endIndex);
-
-    return response;
-  }
-
 
   // Function to "send" the USE_PRIMARY_TCDS aprameter to the HCAL supervisor application. It gets the info from the userXML.
   //protected void getUsePrimaryTCDS(){
@@ -988,6 +949,7 @@ public class HCALEventHandler extends UserEventHandler {
       logger.error(errMessage,e);
     }
   }
+
   protected void publishGlobalParameter (String nameForDB, String parameterName){
     String globalParameterString = ((StringT)functionManager.getHCALparameterSet().get(parameterName).getValue()).getString();
     Parameter<StringT> parameter;
@@ -1006,10 +968,10 @@ public class HCALEventHandler extends UserEventHandler {
       logger.error(errMessage,e);
     }
   }
+
   protected void publishGlobalParameter (String parameterName) {
     publishGlobalParameter(parameterName, parameterName);
   }
-
 
   // make entry into the CMS run info database
   protected void publishRunInfoSummary() {
@@ -2570,6 +2532,7 @@ public class HCALEventHandler extends UserEventHandler {
       throw new UserActionException(errMessage);
     }
   }
+
   // Print of the names of the QR in an arrayList
   void PrintQRnames(List<QualifiedResource> qrlist){
     QualifiedResourceContainer qrc = new QualifiedResourceContainer(qrlist);
@@ -2682,5 +2645,4 @@ public class HCALEventHandler extends UserEventHandler {
     }
     throw new Exception("Property "+name+" not found");
   }
-
 }

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -1419,7 +1419,7 @@ public class HCALEventHandler extends UserEventHandler {
   // find out if all controlled EVMs are happy before stopping the run
   protected boolean isRUBuildersEmpty() {
     if (((FunctionManagerResource)functionManager.getQualifiedGroup().getGroup().getThisResource()).getRole().equals("EvmTrig")) {
-      logger.warn("[HCAL " + functionManager.FMname + "] Checking if the RUs are empty ...");
+      logger.info("[HCAL " + functionManager.FMname + "] Checking if the RUs are empty ...");
     }
 
     boolean reply = true;
@@ -1487,7 +1487,7 @@ public class HCALEventHandler extends UserEventHandler {
 
       if(!freeEvtIdsInFirstIteration .equals(freeEvtIdsValue) && freeEvtIdsInLastIteration.equals(freeEvtIdsValue )) {
         ntry++;
-        logger.warn("[HCAL " + functionManager.FMname + "] Free IDs: " + freeEvtIdsValue);
+        logger.info("[HCAL " + functionManager.FMname + "] Free IDs: " + freeEvtIdsValue);
         if(ntry == 5) {
           String errMessage = "[HCAL " + functionManager.FMname + "] EVM on URI " + app.getResource().getURI().toString() + " seems to have stopped building when not flushed.\nLast number of fre events Ids was: " + freeEvtIdsInLastIteration;
           logger.error(errMessage);
@@ -1757,7 +1757,7 @@ public class HCALEventHandler extends UserEventHandler {
           if ( FedId >= functionManager.firstHBHEaFedId && FedId <= functionManager.lastHBHEaFedId ) {
             if(!functionManager.HBHEain) {
               if (functionManager.FMrole.equals("HCAL")) {
-                logger.warn("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HBHEa FED range.\nEnabling the HBHEa partition.");
+                logger.info("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HBHEa FED range.\nEnabling the HBHEa partition.");
               }
               functionManager.HBHEain = true;
             }
@@ -1765,7 +1765,7 @@ public class HCALEventHandler extends UserEventHandler {
           else if ( FedId >= functionManager.firstHBHEbFedId && FedId <= functionManager.lastHBHEbFedId ) {
             if(!functionManager.HBHEbin) {
               if (functionManager.FMrole.equals("HCAL")) {
-                logger.warn("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HBHEb FED range.\nEnabling the HBHEb partition.");
+                logger.info("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HBHEb FED range.\nEnabling the HBHEb partition.");
               }
               functionManager.HBHEbin = true;
             }
@@ -1773,7 +1773,7 @@ public class HCALEventHandler extends UserEventHandler {
           else if ( FedId >= functionManager.firstHBHEcFedId && FedId <= functionManager.lastHBHEcFedId ) {
             if(!functionManager.HBHEcin) {
               if (functionManager.FMrole.equals("HCAL")) {
-                logger.warn("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HBHEc FED range.\nEnabling the HBHEc partition.");
+                logger.info("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HBHEc FED range.\nEnabling the HBHEc partition.");
               }
               functionManager.HBHEcin = true;
             }
@@ -1781,7 +1781,7 @@ public class HCALEventHandler extends UserEventHandler {
           else if ( FedId >= functionManager.firstHFFedId && FedId <= functionManager.lastHFFedId ) {
             if(!functionManager.HFin) {
               if (functionManager.FMrole.equals("HCAL")) {
-                logger.warn("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HF FED range.\nEnabling the HF partition.");
+                logger.info("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HF FED range.\nEnabling the HF partition.");
               }
               functionManager.HFin = true;
             }
@@ -1789,7 +1789,7 @@ public class HCALEventHandler extends UserEventHandler {
           else if ( FedId >= functionManager.firstHOFedId && FedId <= functionManager.lastHOFedId ) {
             if(!functionManager.HOin) {
               if (functionManager.FMrole.equals("HCAL")) {
-                logger.warn("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HF FED range.\nEnabling the HO partition.");
+                logger.info("[HCAL " + functionManager.FMname + "] FedId = " + FedId + " is in the HCAL HF FED range.\nEnabling the HO partition.");
               }
               functionManager.HOin = true;
             }
@@ -2330,7 +2330,7 @@ public class HCALEventHandler extends UserEventHandler {
                   functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("Stopping the TA ...")));
 
                   if (!SpecialFMsAreControlled) {
-                    logger.warn("[SethLog HCAL " + functionManager.FMname + "] Do functionManager.fireEvent(HCALInputs.STOP)");
+                    logger.info("[HCAL " + functionManager.FMname + "] Do functionManager.fireEvent(HCALInputs.STOP)");
                     functionManager.fireEvent(HCALInputs.STOP);
                   }
 
@@ -2352,7 +2352,7 @@ public class HCALEventHandler extends UserEventHandler {
 
       // stop the TriggerAdapter watchdog thread
       System.out.println("[HCAL " + functionManager.FMname + "] ... stopping TriggerAdapter watchdog thread done.");
-      logger.warn("[SethLog HCAL " + functionManager.FMname + "] ... stopping TriggerAdapter watchdog thread done.");
+      logger.info("[HCAL " + functionManager.FMname + "] ... stopping TriggerAdapter watchdog thread done.");
       TriggerAdapterWatchThreadList.remove(this);
     }
   }

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -1694,9 +1694,6 @@ public class HCALEventHandler extends UserEventHandler {
     // parse FED mask
     String[] FedValueArray = FedEnableMask.split("%");
 
-    // list of misparsed FEDs
-    String errorFEDs = "";
-
     for ( int j=0 ; j<FedValueArray.length ; j++) {
       logger.debug("[HCAL " + functionManager.FMname + "] FED_ENABLE_MASK parsing: testing " + FedValueArray[j]);
 
@@ -2161,8 +2158,6 @@ public class HCALEventHandler extends UserEventHandler {
       int icount = 0;
       while ((stopHCALSupervisorWatchThread == false) && (functionManager != null) && (functionManager.isDestroyed() == false)) {
         icount++;
-        Date now = Calendar.getInstance().getTime();
-
         // poll HCAL supervisor status in the Configuring/Configured/Running/RunningDegraded states every 5 sec to see if it is still alive  (dangerous because ERROR state is reported wrongly quite frequently)
         if (icount%5==0) {
           if ((functionManager.getState().getStateString().equals(HCALStates.CONFIGURING.toString()) ||
@@ -2180,8 +2175,6 @@ public class HCALEventHandler extends UserEventHandler {
               String status   = "undefined";
               String stateName   = "undefined";
               String progressFromSupervisor = "undefined";
-              String taname   = "undefined";
-
               // ask for the status of the HCAL supervisor
               for (QualifiedResource qr : functionManager.containerhcalSupervisor.getApplications() ){
                 try {
@@ -2267,8 +2260,6 @@ public class HCALEventHandler extends UserEventHandler {
       int icount = 0;
       while ((stopTriggerAdapterWatchThread == false) && (functionManager != null) && (functionManager.isDestroyed() == false)) {
         icount++;
-        Date now = Calendar.getInstance().getTime();
-
         // poll TriggerAdapter status every 1 sec
         if (icount%1==0) {
           if ((functionManager != null) && (functionManager.isDestroyed() == false) && ((functionManager.getState().getStateString().equals(HCALStates.RUNNING.toString())) ||
@@ -2431,6 +2422,7 @@ public class HCALEventHandler extends UserEventHandler {
 
       stopAlarmerWatchThread = false;
       try {
+        @SuppressWarnings("unused")
         URL alarmerURL = new URL(functionManager.alarmerURL);
       } catch (MalformedURLException e) {
         // in case the URL is bogus, just don't run the thread
@@ -2440,8 +2432,6 @@ public class HCALEventHandler extends UserEventHandler {
 
       // poll alarmer status in the Running/RunningDegraded states every 30 sec to see if it is still OK/alive
       while ((stopAlarmerWatchThread == false) && (functionManager != null) && (functionManager.isDestroyed() == false)) {
-        Date now = Calendar.getInstance().getTime();
-
         FMstate = functionManager.getState().getStateString();
         if (FMstate.equals(HCALStates.RUNNING.toString()) || FMstate.equals(HCALStates.RUNNINGDEGRADED.toString()) ) {
           try {

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -211,15 +211,6 @@ public class HCALFunctionManager extends UserFunctionManager {
   public WSESubscription wsSubscription = null;  
   public String RunInfoFlashlistName = "empty";
 
-  // switch to use or not use zero suppression given by a HCAL CFG snippet
-  public boolean useZS = true;
-
-  // switch to use or not use the special zero suppression given by a HCAL CFG snippet (to use it also the standard useZS = true is needed so this snippet will be used too)
-  public boolean useSpecialZS = true;
-
-  // switch to enable special configuration snippets needed for the VdM scan
-  public boolean useVdMSnippet = false;
-
   // switch to find out if this FM is configuring for the very first time
   protected Boolean VeryFirstConfigure = true;
 
@@ -357,38 +348,6 @@ public class HCALFunctionManager extends UserFunctionManager {
 
     System.out.println("[HCAL " + FMname + "] destroyAction called");
     logger.info("[HCAL " + FMname + "] destroyAction called");
-
-    
-    // if RunInfo database is connected try to report the destroying of this FM
-    /*if ((HCALRunInfo!=null) && (RunWasStarted)) {
-      {
-      Date date = new Date();
-      Parameter<DateT> stoptime = new Parameter<DateT>("TIME_ON_EXIT",new DateT(date));
-      try {
-      logger.debug("[HCAL " + FMname + "] Publishing to the RunInfo DB TIME_ONE_EXIT: " + date.toString());
-      if (HCALRunInfo != null) { HCALRunInfo.publish(stoptime); }
-      }
-      catch (RunInfoException e) {
-      String errMessage = "[HCAL " + FMname + "] Error! RunInfoException: something seriously went wrong when publishing the run time on exit ...\nProbably this is OK when the FM was destroyed.";
-      logger.error(errMessage,e);
-    // supressed to not worry the CDAQ shifter sendCMSError(errMessage);
-    }
-    }
-    {
-    Parameter<StringT> StateOnExit = new Parameter<StringT>("STATE_ON_EXIT",new StringT(getState().getStateString()));
-    try {
-    logger.debug("[HCAL " + FMname + "] Publishing to the RunInfo DB STATE_ON_EXIT: " + getState().getStateString());
-    if (HCALRunInfo != null) { HCALRunInfo.publish(StateOnExit); }
-    }
-    catch (RunInfoException e) {
-    String errMessage = "[HCAL " + FMname + "] Error! RunInfoException: something seriously went wrong when publishing the run state on exit ...\nProbably this is OK when the FM was destroyed.";
-    logger.error(errMessage,e);
-    // supressed to not worry the CDAQ shifter sendCMSError(errMessage);
-    }
-    }
-
-    HCALRunInfo = null; // make RunInfo ready for the next round of run info to store
-    }*/
 
     // LV1 should try to close any open session ID not requested by LV0 
     if ( !getQualifiedGroup().seekQualifiedResourcesOfType(new FunctionManager()).isEmpty()) {

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -343,10 +343,10 @@ public class HCALFunctionManager extends UserFunctionManager {
 
     destroyed = false;
 
-    logger.warn("JohnLog: about to construct HCALParameterSender.");
+    logger.info("[HCAL " + FMname + "]: about to construct HCALParameterSender.");
     this.parameterSender = new HCALParameterSender(this);
     this.parameterSender.start();
-    logger.warn("JohnLog: finished calling HCALParameterSender.start()");
+    logger.info("[HCAL " + FMname + "]: finished calling HCALParameterSender.start()");
 
     System.out.println("[HCAL " + FMname + "] createAction executed ...");
     logger.debug("[HCAL " + FMname + "] createAction executed ...");

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -229,13 +229,6 @@ public class HCALMasker {
         }
     }
 
-
-    for (Map.Entry<String, Resource> entry : candidates.entrySet()) {
-      String key = entry.getKey();
-      //logger.warn("[JohnLog2] key:" + key);
-   }
-  
-  
     return candidates;
   }
 

--- a/src/rcms/fm/app/level1/HCALParameterSender.java
+++ b/src/rcms/fm/app/level1/HCALParameterSender.java
@@ -51,8 +51,7 @@ public class HCALParameterSender implements Runnable {
 	public HCALParameterSender(HCALFunctionManager parentFunctionManager) {
     this.logger = new RCMSLogger(HCALFunctionManager.class);
 		this.functionManager = parentFunctionManager;
-    HCALParameters test = parentFunctionManager.getHCALparameterSet();
-		this.previousParameterSetSnapshot = this.functionManager.getHCALparameterSet().getClonedParameterSet();
+    this.previousParameterSetSnapshot = this.functionManager.getHCALparameterSet().getClonedParameterSet();
 		this.executorService = Executors.newSingleThreadScheduledExecutor();
 	}
 

--- a/src/rcms/fm/app/level1/HCALSetParameterHandler.java
+++ b/src/rcms/fm/app/level1/HCALSetParameterHandler.java
@@ -53,7 +53,7 @@ public class HCALSetParameterHandler extends UserEventHandler {
 	 * call back executed when a parameterSet event is processed.
 	 */
         public void onParameterSet(ParameterSet parameters) throws UserActionException {
-		logger.warn("[HCALSetParameterHandler] onParameterSet called: functionManager = " + functionManager );
+		logger.info("[HCALSetParameterHandler] onParameterSet called: functionManager = " + functionManager );
 
 
 	}

--- a/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
+++ b/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
@@ -56,9 +56,6 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
       //    "from this state: " + notification.getFromState()  +
       //    " to this state: " + notification.getToState());
       
-      String actualState = fm.getState().getStateString();
-      //logger.warn("["+fm.FMname+"]: FM is in state: "+actualState);
-
       if ( fm.getState().equals(HCALStates.ERROR) ) {
         return;
       }
@@ -216,8 +213,6 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
       if(taskSequence == null) {
 
         setTimeoutThread(false);
-        String infomsg = "Received a State Notification while taskSequence is null \n";
-
         logger.debug("FM is in local mode");
         fm.theEventHandler.computeNewState(notification);
         return;
@@ -285,9 +280,6 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
      *
      */
     protected void completeTransition() throws UserActionException, Exception {
- 
-        State FMState = fm.getState();
- 
         fm.setAction("Transition Completed");
  
         if (taskSequence.getCompletionEvent().equals(HCALInputs.SETCONFIGURE) ) {

--- a/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
+++ b/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
@@ -55,6 +55,9 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
       //    "from this FM/app "+  notification.getIdentifier() +
       //    "from this state: " + notification.getFromState()  +
       //    " to this state: " + notification.getToState());
+
+      //String actualState = fm.getState().getStateString();
+      //logger.warn("["+fm.FMname+"]: FM is in state: "+actualState);
       
       if ( fm.getState().equals(HCALStates.ERROR) ) {
         return;

--- a/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
+++ b/src/rcms/fm/app/level1/HCALStateNotificationHandler.java
@@ -215,8 +215,10 @@ public class HCALStateNotificationHandler extends UserEventHandler  {
 
       if(taskSequence == null) {
 
+        String infomsg = "Received a State Notification while taskSequence is null \n";
+
         setTimeoutThread(false);
-        logger.debug("FM is in local mode");
+        logger.debug(infomsg);
         fm.theEventHandler.computeNewState(notification);
         return;
     }

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -705,8 +705,8 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           String errMessage = "[HCAL LVL1 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + GlobalRunkey + ". HCAL does not use a global RUN_KEY.";
           logger.error(errMessage);
           functionManager.sendCMSError(errMessage);
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
           functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - problems ...")));
+          //functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
           //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
         }
       }

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -311,7 +311,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           if (functionManager.FMrole.equals("HCAL")) {
             LocalRunkeySelected = "global_HCAL";
             MastersnippetSelected = xmlHandler.getNamedXMLelementAttributeValue("LocalRunkey", LocalRunkeySelected, "snippet",true);
-            logger.warn("[JohnLog3] " + functionManager.FMname + ": This level1 with role " + functionManager.FMrole + " thinks we are in global mode and thus picked the LocalRunkeySelected = " + MastersnippetSelected );
+            logger.info("[HCAL " + functionManager.FMname + "]: This level1 with role " + functionManager.FMrole + " thinks we are in global mode and thus picked the LocalRunkeySelected = " + MastersnippetSelected );
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("MASTERSNIPPET_SELECTED",new StringT(MastersnippetSelected)));
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("LOCAL_RUNKEY_SELECTED",new StringT(LocalRunkeySelected)));
           }
@@ -329,7 +329,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("MASTERSNIPPET_SELECTED", new StringT(MastersnippetSelected)));
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("LOCAL_RUNKEY_SELECTED", new StringT(LocalRunkeySelected)));
       }else{
-        logger.warn("[Martin log] "+functionManager.FMname + ": Did not get mastersnippet info from GUI (for local run) or from LV0(for global).");
+        logger.warn("[HCAL "+functionManager.FMname + "]: Did not get mastersnippet info from GUI (for local run) or from LV0(for global).");
       }
     
       //Check to see if maskedapps has an instance number
@@ -356,7 +356,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       if( qg.getRegistryEntry("SID") ==null){
         Integer sid = ((IntegerT)functionManager.getHCALparameterSet().get("SID").getValue()).getInteger();
         qg.putRegistryEntry("SID", sid);
-        logger.warn("[HCAL "+ functionManager.FMname+"] Just set the SID of QG to "+ sid);
+        logger.info("[HCAL "+ functionManager.FMname+"] Just set the SID of QG to "+ sid);
       }
       else{
         logger.info("[HCAL "+ functionManager.FMname+"] SID of QG is "+ qg.getRegistryEntry("SID"));
@@ -623,7 +623,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           TpgKey = ((StringT)parameterSet.get("TPG_KEY").getValue()).getString();
           functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("CONFIGURED_WITH_TPG_KEY",new StringT(TpgKey)));
           String warnMessage = "[HCAL LVL1 " + functionManager.FMname + "] Received a L1 TPG key: " + TpgKey;
-          logger.warn(warnMessage);
+          logger.info(warnMessage);
         }
         else {
           String warnMessage = "[HCAL LVL1 " + functionManager.FMname + "] Did not receive a L1 TPG key.\nThis is only OK for HCAL local run operations or if HCAL is out of the trigger for global runs ...";
@@ -861,7 +861,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         }
       }
       else{
-        logger.warn("[HCAL LVL1 " + functionManager.FMname + "] Starting AlarmerWatchThread ...");
+        logger.info("[HCAL LVL1 " + functionManager.FMname + "] Starting AlarmerWatchThread ...");
         alarmerthread = new AlarmerWatchThread();
         alarmerthread.start();
       }
@@ -901,7 +901,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       for(QualifiedResource qr : fmChildrenList) {
         String childFMName = qr.getName();
         if (maskedChildFMs.contains(childFMName)) {
-          logger.warn("[HCAL LVL1 " + functionManager.FMname + "] DavidLog -- Based on FED_ENABLE_MASK, I am attempting to destroy FM XDAQ " + childFMName + "." );
+          logger.info("[HCAL LVL1 " + functionManager.FMname + "]: Based on FED_ENABLE_MASK, I am attempting to destroy FM XDAQ " + childFMName + "." );
 
           // Check that the partition is not responsible for event building/triggering
           if (childFMName.equals(evmTrigFM)) {
@@ -1157,7 +1157,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           startTaskSeq.addLast(TTCciTask);
         }
 
-      logger.warn("[SethLog HCAL LVL1 " + functionManager.FMname + "] executeTaskSequence.");
+      logger.info("[HCAL LVL1 " + functionManager.FMname + "] executeTaskSequence.");
       functionManager.theStateNotificationHandler.executeTaskSequence(startTaskSeq);
       }
 
@@ -1350,7 +1350,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           logger.info("[HCAL LVL1 " + functionManager.FMname +"]  Adding other LV2 FMs to haltTask: ");
           PrintQRnames(normalFMsToHaltContainer);
         }
-        logger.warn("[SethLog HCAL LVL1 " + functionManager.FMname + "] executeTaskSequence.");
+        logger.info("[HCAL LVL1 " + functionManager.FMname + "] executeTaskSequence.");
 
         functionManager.theStateNotificationHandler.executeTaskSequence(haltTaskSeq);
       }
@@ -1440,7 +1440,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
     if (obj instanceof StateNotification) {
 
       // triggered by State Notification from child resource
-      logger.warn("[SethLog HCAL LVL1 " + functionManager.FMname + "] Received state notification inside stoppingAction(); computeNewState()");
+      logger.info("[HCAL LVL1 " + functionManager.FMname + "] Received state notification inside stoppingAction(); computeNewState()");
       computeNewState((StateNotification) obj);
       return;
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -698,14 +698,17 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       functionManager.RunType = RunType;
       logger.info("[HCAL LVL1 " + functionManager.FMname + "] configureAction: We are in " + RunType + " mode ...");
 
-      if (!GlobalRunkey.equals("")) {
-        // Send an error to the L0 GUI if we are given a nonsense global run key, but do not go to error state.
-        String errMessage = "[HCAL LVL1 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + GlobalRunkey + ". HCAL does not use a global RUN_KEY.";
-        logger.error(errMessage);
-        functionManager.sendCMSError(errMessage);
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - problems ...")));
-        //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
+      if (parameterSet.get("RUN_KEY") != null) {
+        GlobalRunkey = ((StringT)parameterSet.get("RUN_KEY").getValue()).getString();
+        if (!GlobalRunkey.equals("")) {
+          // Send an error to the L0 GUI if we are given a nonsense global run key, but do not go to error state.
+          String errMessage = "[HCAL LVL1 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + GlobalRunkey + ". HCAL does not use a global RUN_KEY.";
+          logger.error(errMessage);
+          functionManager.sendCMSError(errMessage);
+          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
+          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - problems ...")));
+          //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
+        }
       }
 
       // check if the RUN_KEY has changed

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -951,8 +951,6 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         logger.debug("[HCAL LVL1 " + functionManager.FMname + "] Found FM childs - good! fireEvent: " + configureInput);
 
 
-        Boolean needtowait = false;
-
         // include scheduling
         TaskSequence configureTaskSeq = new TaskSequence(HCALStates.CONFIGURING,HCALInputs.SETCONFIGURE);
 

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -102,7 +102,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           logger.info("[Martin log HCAL LVL2 " + functionManager.FMname + "] Received the following SID from LV1 :"+ Sid) ;
         }
         else {
-          String warnMessage = "[Martin log HCAL LVL2 " + functionManager.FMname + "] Did not receive a SID from LV1...";
+          String warnMessage = "[HCAL LVL2 " + functionManager.FMname + "] Did not receive a SID from LV1...";
           logger.warn(warnMessage);
         }
 
@@ -145,7 +145,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       if( qg.getRegistryEntry("SID") ==null){
         Integer sid = ((IntegerT)functionManager.getHCALparameterSet().get("SID").getValue()).getInteger();
         qg.putRegistryEntry("SID", Integer.toString(sid));
-        logger.warn("[HCAL "+ functionManager.FMname+"] Just set the SID of QG to "+ sid);
+        logger.info("[HCAL "+ functionManager.FMname+"] Just set the SID of QG to "+ sid);
       }
       else{
         logger.info("[HCAL "+ functionManager.FMname+"] SID of QG is "+ qg.getRegistryEntry("SID"));
@@ -717,14 +717,14 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         }
         else{
           //Destroy XDAQ() for this FM
-          logger.warn("[HCAL LV2 "+ functionManager.FMname +"] Going to destroyXDAQ for this FM as it is masked from FED list");
+          logger.info("[HCAL LV2 "+ functionManager.FMname +"] Going to destroyXDAQ for this FM as it is masked from FED list");
           stopHCALSupervisorWatchThread = true;
           functionManager.destroyXDAQ();
           functionManager.fireEvent( HCALInputs.SETCONFIGURE );
         }
       }
       else{
-        logger.warn("[HCAL LV2 "+ functionManager.FMname +"] Did not receive EMPTY_FMS from LV1.");
+        logger.info("[HCAL LV2 "+ functionManager.FMname +"] Did not receive EMPTY_FMS from LV1.");
       }
       // set actions
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
@@ -795,7 +795,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       VectorT<StringT> EmptyFMs  = (VectorT<StringT>)functionManager.getHCALparameterSet().get("EMPTY_FMS").getValue();
       if (EmptyFMs.contains(new StringT(functionManager.FMname))){
         //Start EmptyFM
-        logger.warn("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Starting EmptyFM");
+        logger.info("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Starting EmptyFM");
         functionManager.fireEvent( HCALInputs.SETSTART ); 
         // set action
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
@@ -1050,7 +1050,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       VectorT<StringT> EmptyFMs  = (VectorT<StringT>)functionManager.getHCALparameterSet().get("EMPTY_FMS").getValue();
       if (EmptyFMs.contains(new StringT(functionManager.FMname))){
         //Stop EmptyFM
-        logger.warn("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Pausing EmptyFM");
+        logger.info("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Pausing EmptyFM");
         functionManager.fireEvent( HCALInputs.SETPAUSE ); 
         // set actions
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
@@ -1113,7 +1113,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       VectorT<StringT> EmptyFMs  = (VectorT<StringT>)functionManager.getHCALparameterSet().get("EMPTY_FMS").getValue();
       if (EmptyFMs.contains(new StringT(functionManager.FMname))){
         // Resume EmptyFM
-        logger.warn("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Resuming EmptyFM");
+        logger.info("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Resuming EmptyFM");
         functionManager.fireEvent( HCALInputs.SETRESUME ); 
         // set actions
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
@@ -1235,7 +1235,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! No HCAL supervisor found: haltAction()";
         functionManager.goToError(errMessage);
       } 
-      logger.warn("[HCAL LVL2 " + functionManager.FMname + "] executing Halt TaskSequence.");
+      logger.info("[HCAL LVL2 " + functionManager.FMname + "] executing Halt TaskSequence.");
       functionManager.theStateNotificationHandler.executeTaskSequence(LV2haltTaskSeq);
 
       // Reset the EmptyFMs for all LV2s
@@ -1413,7 +1413,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       VectorT<StringT> EmptyFMs  = (VectorT<StringT>)functionManager.getHCALparameterSet().get("EMPTY_FMS").getValue();
       if (EmptyFMs.contains(new StringT(functionManager.FMname))){
         //Stop EmptyFM
-        logger.warn("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Stopping EmptyFM");
+        logger.info("[HCAL LV2 "+ functionManager.FMname +"] This FM is empty. Stopping EmptyFM");
         functionManager.fireEvent( HCALInputs.SETCONFIGURE ); 
         // set actions
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
@@ -1776,15 +1776,15 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
 
     public TTCciWatchThread(HCALFunctionManager parentFunctionManager) {
       this.logger = new RCMSLogger(HCALFunctionManager.class);
-      logger.warn("Constructing TTCciWatchThread");
+      logger.info("Constructing TTCciWatchThread");
       this.functionManager = parentFunctionManager;
-      logger.warn("Done construction TTCciWatchThread for " + functionManager.FMname + ".");
+      logger.info("Done construction TTCciWatchThread for " + functionManager.FMname + ".");
     }
     public void run() {
       while (!stopTTCciWatchThread && !functionManager.isDestroyed() && functionManager != null) {
           for (QualifiedResource ttcciControlResource : functionManager.containerTTCciControl.getApplications()) {
             XdaqApplication ttcciControl = (XdaqApplication) ttcciControlResource;
-            logger.warn("[JohnLog] " + functionManager.FMname + ": " + ttcciControl.getName() + " has state: " + ttcciControl.refreshState().toString());
+            logger.info("[HCAL " + functionManager.FMname + "]: " + ttcciControl.getName() + " has state: " + ttcciControl.refreshState().toString());
             //Poll the xdaq to issue transitions
             if (ttcciControl.refreshState().toString().equals("configured") ) {
               // Running To Stopping
@@ -1850,7 +1850,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
             }
         } 
       }
-      logger.warn("[HCAL " + functionManager.FMname + "] ... stopping TTCci watchdog thread done.");
+      logger.info("[HCAL " + functionManager.FMname + "] ... stopping TTCci watchdog thread done.");
     }
   }
 }

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -548,42 +548,16 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       functionManager.RunType = RunType;
       logger.info("[HCAL LVL2 " + functionManager.FMname + "] configureAction: We are in " + RunType + " mode ...");
 
-      // switch parsing, etc. of the zero supression HCAL CFG snippet on or off, special zero suppression handling ...
-      if (RunKey.equals("noZS") || RunKey.equals("VdM-noZS")) {
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] The zero supression is switched off ...");
-        functionManager.useZS        = false;
-        functionManager.useSpecialZS = false;
-      }
-      else if (RunKey.equals("test-ZS") || RunKey.equals("VdM-test-ZS")) {
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] The special zero suppression is switched on i.e. not blocked by this FM ...");
-        functionManager.useZS        = false;
-        functionManager.useSpecialZS = true;
-      }
-      else if (RunKey.equals("ZS") || RunKey.equals("VdM-ZS")) {
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] The zero suppression is switched on i.e. not blocked by this FM ...");
-        functionManager.useZS        = true;
-        functionManager.useSpecialZS = false;
-
-      }
-      else {
-        if (!RunKey.equals("")) {
-          String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + RunKey + " - please check the RS3 config in use!\nPerhaps the wrong key was given by the CDAQ shifter!?";
-          logger.error(errMessage);
-          functionManager.sendCMSError(errMessage);
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - technical difficulties ...")));
-          if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
-        }
+      if (!GlobalRunkey.equals("")) {
+        // Send an error to the L0 if it gives us a nonsense global run key, but do not go to error state.
+        String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + GlobalRunkey + ". HCAL does not use a global RUN_KEY.";
+        logger.error(errMessage);
+        functionManager.sendCMSError(errMessage);
+        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
+        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - technical difficulties ...")));
+        //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
       }
 
-      // check the RUN_KEY for VdM snippets, etc. request
-      if (RunKey.equals("VdM-noZS") || RunKey.equals("VdM-test-ZS") || RunKey.equals("VdM-ZS")) {
-        logger.warn("[HCAL LVL2 " + functionManager.FMname + "] Special VdM scan snippets, etc. were enabled by the RUN_KEY for this FM.\nThe RUN_KEY given is: " + RunKey);
-        functionManager.useVdMSnippet = true;
-      }
-      else {
-        logger.debug("[HCAL LVL2 " + functionManager.FMname + "] No special VdM scan snippets, etc. enabled for this FM.\nThe RUN_KEY given is: " + RunKey);
-      }
 
       if (TpgKey!=null && TpgKey!="NULL") {
 

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -158,7 +158,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         VectorT<StringT> MaskedResources = (VectorT<StringT>)parameterSet.get("MASKED_RESOURCES").getValue();
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<VectorT<StringT>>("MASKED_RESOURCES",MaskedResources));
         StringT[] MaskedResourceArray = MaskedResources.toArray(new StringT[MaskedResources.size()]);
-        List<QualifiedResource> level2list = qg.seekQualifiedResourcesOfType(new FunctionManager());
         for (StringT MaskedApplication : MaskedResourceArray) {
           //String MaskedAppWcolonsNoCommas = MaskedApplication.replace("," , ":");
           //logger.info("[JohnLog2] " + functionManager.FMname + ": " + functionManager.FMname + ": Starting to mask application " + MaskedApplication);
@@ -437,12 +436,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
      
       String CfgCVSBasePath           = "not set";
-      String LVL1CfgScript            = "not set";
-      String LVL1TTCciControlSequence = "not set";
-      String LVL1LTCControlSequence   = "not set";
-      String LVL1TCDSControlSequence   = "not set";
-      String LVL1LPMControlSequence   = "not set";
-      String LVL1PIControlSequence = "not set";
+
       // Set the default value everytime we configure
       boolean isSinglePartition   = false; 
       String ICIControlSequence   = "not set";
@@ -1533,10 +1527,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("calculating state")));
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("preparingTestMode")));
 
-      String LVL1CfgScript            = "not set";
-      String LVL1TTCciControlSequence = "not set";
-      String LVL1LTCControlSequence   = "not set";
-
       // get the parameters of the command
       ParameterSet<CommandParameter> parameterSet = getUserFunctionManager().getLastInput().getParameterSet();
 
@@ -1560,9 +1550,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
 
       CfgCVSBasePath           = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGCVSBASEPATH").getValue()).getString();
       FullCfgScript            = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGSCRIPT"     ).getValue()).getString();
-      String TTCciControlSequence = ((StringT)functionManager.getHCALparameterSet().get("HCAL_TTCCICONTROL"  ).getValue()).getString();
-      String LTCControlSequence   = ((StringT)functionManager.getHCALparameterSet().get("HCAL_LTCCONTROL"    ).getValue()).getString();
-      
 
       // configuring all created HCAL applications by means of sending the RunType to the HCAL supervisor
       // KKH: resurrect this if you want to fix prepareTTStestmode

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -548,14 +548,17 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       functionManager.RunType = RunType;
       logger.info("[HCAL LVL2 " + functionManager.FMname + "] configureAction: We are in " + RunType + " mode ...");
 
-      if (!GlobalRunkey.equals("")) {
-        // Send an error to the L0 if it gives us a nonsense global run key, but do not go to error state.
-        String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + GlobalRunkey + ". HCAL does not use a global RUN_KEY.";
-        logger.error(errMessage);
-        functionManager.sendCMSError(errMessage);
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - technical difficulties ...")));
-        //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
+      if (parameterSet.get("RUN_KEY") != null) {
+        GlobalRunkey = ((StringT)parameterSet.get("RUN_KEY").getValue()).getString();
+        if (!GlobalRunkey.equals("")) {
+          // Send an error to the L0 if it gives us a nonsense global run key, but do not go to error state.
+          String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + GlobalRunkey + ". HCAL does not use a global RUN_KEY.";
+          logger.error(errMessage);
+          functionManager.sendCMSError(errMessage);
+          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
+          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - technical difficulties ...")));
+          //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
+        }
       }
 
 

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -1527,6 +1527,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
 
       CfgCVSBasePath           = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGCVSBASEPATH").getValue()).getString();
       FullCfgScript            = ((StringT)functionManager.getHCALparameterSet().get("HCAL_CFGSCRIPT"     ).getValue()).getString();
+      //String TTCciControlSequence = ((StringT)functionManager.getHCALparameterSet().get("HCAL_TTCCICONTROL"  ).getValue()).getString();
+      //String LTCControlSequence   = ((StringT)functionManager.getHCALparameterSet().get("HCAL_LTCCONTROL"    ).getValue()).getString();
 
       // configuring all created HCAL applications by means of sending the RunType to the HCAL supervisor
       // KKH: resurrect this if you want to fix prepareTTStestmode

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -555,8 +555,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Do not understand how to handle this RUN_KEY: " + GlobalRunkey + ". HCAL does not use a global RUN_KEY.";
           logger.error(errMessage);
           functionManager.sendCMSError(errMessage);
-          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
           functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - technical difficulties ...")));
+          //functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
           //if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return; }
         }
       }

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -379,9 +379,7 @@ public class HCALxmlHandler {
   }  
 
   public String addStateListenerContext(String execXMLstring, String rcmsStateListenerURL) throws UserActionException{
-    String newExecXMLstring = "";
     try {
-
       //System.out.println(execXMLstring);
       docBuilder = docBuilderFactory.newDocumentBuilder();
       InputSource inputSource = new InputSource();
@@ -417,8 +415,6 @@ public class HCALxmlHandler {
 
   public String setUTCPConnectOnRequest(String execXMLstring) throws UserActionException{
     try {
-      String newExecXMLstring = "";
-
       docBuilder = docBuilderFactory.newDocumentBuilder();
       InputSource inputSource = new InputSource();
       inputSource.setCharacterStream(new StringReader(execXMLstring));
@@ -857,7 +853,6 @@ public class HCALxmlHandler {
   }
   public String getTagTextContent(NodeList inputlist, String TagName) throws UserActionException{  
     String TagContent = "";
-    boolean HasUniqueTag = false;
     //Return empty string if we do not have a unique Tag in mastersnippet. 
     if( !hasUniqueTag(inputlist,TagName) ){
       return TagContent;

--- a/src/rcms/fm/app/level1/HCALxmlHandler.java
+++ b/src/rcms/fm/app/level1/HCALxmlHandler.java
@@ -78,9 +78,9 @@ public class HCALxmlHandler {
 
   public HCALxmlHandler(HCALFunctionManager parentFunctionManager) {
     this.logger = new RCMSLogger(HCALFunctionManager.class);
-    logger.warn("Constructing xmlHandler.");
+    logger.info("Constructing xmlHandler.");
     this.functionManager = parentFunctionManager;
-    logger.warn("Done constructing xmlHandler.");
+    logger.info("Done constructing xmlHandler.");
   }
 
   static class HCALxmlErrorHandler implements ErrorHandler {
@@ -260,23 +260,23 @@ public class HCALxmlHandler {
       if (!hcalXML.equals(null) && !hcalXML.getElementsByTagName(tag).equals(null)) {
         if (hcalXML.getElementsByTagName(tag).getLength()!=0) {
           NodeList nodes = hcalXML.getElementsByTagName(tag); 
-          logger.warn("[JohnLog3] " + functionManager.FMname + ": the length of the list of nodes with tag name '" + tag + "' is: " + nodes.getLength());
+          logger.info("["+ functionManager.FMname + "]: the length of the list of nodes with tag name '" + tag + "' is: " + nodes.getLength());
           for (int iNode = 0; iNode < nodes.getLength(); iNode++) {
-            logger.warn("[JohnLog3] " + functionManager.FMname + " found a userXML element with tagname '" + tag + "' and name '" + ((Element)nodes.item(iNode)).getAttributes().getNamedItem("name").getNodeValue()  + "'"); 
+            logger.info("[" + functionManager.FMname + "]: found a userXML element with tagname '" + tag + "' and name '" + ((Element)nodes.item(iNode)).getAttributes().getNamedItem("name").getNodeValue()  + "'"); 
             if (((Element)nodes.item(iNode)).getAttributes().getNamedItem("name").getNodeValue().equals(name)) {
                foundTheRequestedNamedElement = true;
                if ( ((Element)nodes.item(iNode)).hasAttribute(attribute)) {
                   return ((Element)nodes.item(iNode)).getAttributes().getNamedItem(attribute).getNodeValue();
                }else{
-                  logger.warn("[Martin log "+functionManager.FMname+"] Does not found the attribute='"+attribute+"' with name='"+name+"' in tag='"+tag+"'. Empty string will be returned");
+                  logger.info("["+functionManager.FMname+"] Did not found the attribute='"+attribute+"' with name='"+name+"' in tag='"+tag+"'. Empty string will be returned");
                   String emptyString = "";
                   return emptyString;
                }
             }
           }
           if (!foundTheRequestedNamedElement) {
-            String errMessage = "[JohnLog3] " + functionManager.FMname + ": this FM requested the value of the attribute '" + attribute + "' from a userXML element with tag '" + tag + "' and name '" + name + "' but that name did not exist in that element. Empty String is returned.";
-            logger.warn(errMessage);
+            String errMessage = "[HCAL " + functionManager.FMname + "]: this FM requested the value of the attribute '" + attribute + "' from a userXML element with tag '" + tag + "' and name '" + name + "' but that name did not exist in that element. Empty String is returned.";
+            logger.info(errMessage);
             String emptyString = "";
             return emptyString;
             //throw new UserActionException("[HCAL " + functionManager.FMname + "]: " + errMessage);
@@ -284,7 +284,7 @@ public class HCALxmlHandler {
         }
         else {
           //throw new UserActionException("[HCAL " + functionManager.FMname + "]: A userXML element with tag name '" + tag + "'" + "was not found in the userXML. Empty String will be returned.");
-          logger.warn("[HCAL " + functionManager.FMname + "]: A userXML element with tag name '" + tag + "'" + "was not found in the userXML. Empty String will be returned.");
+          logger.info("[HCAL " + functionManager.FMname + "]: A userXML element with tag name '" + tag + "'" + "was not found in the userXML. Empty String will be returned.");
           String emptyElement="";
           return  emptyElement;
         }
@@ -876,7 +876,7 @@ public class HCALxmlHandler {
           tmpAttribute = TagElement.getAttributes().getNamedItem(attribute).getNodeValue();
       }
       else{
-          logger.warn("[Martin log "+functionManager.FMname+"] Did not find the attribute='"+attribute+" in tag='"+TagName+"'.");
+          logger.info("[HCAL "+functionManager.FMname+"]: Did not find the attribute='"+attribute+" in tag='"+TagName+"'.");
           return tmpAttribute;
       }
       return tmpAttribute;


### PR DESCRIPTION
remove unused variables, reduce warn messages, remove logic for global run keys, new name for global run key in the code, remove unused methods of HCALEventHandler

also send an error message to level0 if we get a non-empty global run key, but do not go to error state