### PR TITLE
Support HBHE FM

### DIFF
--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -976,6 +976,11 @@ public class HCALFunctionManager extends UserFunctionManager {
         if (FMpartition.contains("HBHEa"))  {          loopMap  = TCDS_HBHEa;        }
         if (FMpartition.contains("HBHEb"))  {          loopMap  = TCDS_HBHEb;        }
         if (FMpartition.contains("HBHEc"))  {          loopMap  = TCDS_HBHEc;        }
+        if (FMpartition.equals("HBHE"))  { 
+            loopMap  = TCDS_HBHEa; 
+            loopMap.putAll(TCDS_HBHEb);
+            loopMap.putAll(TCDS_HBHEc);
+        }
         if (FMpartition.contains("HO"))     {          loopMap  = TCDS_HO;           }
         if (FMpartition.contains("HF"))     {          loopMap  = TCDS_HF;           }
         if (FMpartition.contains("Laser"))  {          loopMap  = TCDS_Laser;        }


### PR DESCRIPTION
HBHEabc FM needs to be merged into a single LV2 FM because all HE front ends are getting TTS/TTC from HBHEc TCDS and therefore essentially tied three HBHE partitions together.  
Configuration changes is noted here:
`https://gitlab.cern.ch/cmshcos/hcalConfMagik/issues/14`
hcos changes to support multiple set of ICI/PI/LMP under same supervisor is done here:
`https://gitlab.cern.ch/cmshcos/hcal/merge_requests/215`

This PR implements the remaining support on the FM side for 
 - Releasing all HBHEabc's TCDS lease for HBHE FM
 - Watching/Ignoring all HBHEabc partition based on whether or not HBHE FM is `EMPTY_FM` 

Tested at P5 with miniDAQ.