### PR TITLE
Add URI of the error app from supervisor infospace, gui fixes

### DIFF
--- a/gui/css/hcalcontrol.css
+++ b/gui/css/hcalcontrol.css
@@ -586,7 +586,8 @@ a {
     padding-left: 8px;
     padding-right: 8px;
 }
-.errAppName {
+.errAppName a {
     color: #dd0000;
     font-weight: 700;
+    font-size: unset;
 }

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -61,8 +61,11 @@ function showErrorTable() {
         errTableHTML += "<td class='errMessage'>"   +        errVector[i]["message"]   + "</td></tr>";
       }
       errTableHTML += "</table>";
-      $("#errMapError").html(errTableHTML);
     }
+    else {
+      errTableHTML = "";
+    }
+    $("#errMapError").html(errTableHTML);
 }
 function setStateColors() {
   $('#currentState').attr("class", "hcal_control_" + $('#currentState').text());
@@ -426,10 +429,16 @@ function spectatorMode(onOff) {
     $('input').not("#FMPilotForm > input").attr("disabled", true);
     $('#dropdown').css("pointer-events: none;");
     $('#dropdown').attr("disabled", true);
-    var spectatorAllowed = ["Detach", "UpdatedRefresh", "showTreeButton", "showStatusTableButton", "refreshGlobalParametersButton", "runParametersCheckbox", "globalParametersCheckbox", "showFullMasks", "drive"];
+    var spectatorAllowed = ["Detach", "UpdatedRefresh", "showTreeButton", "showStatusTableButton", 
+                            "refreshGlobalParametersButton", "runParametersCheckbox", 
+                            "globalParametersCheckbox", "showFullMasks", "drive", "quickInfoButton"];
     $.each(spectatorAllowed, function(index, id) {
       $('#' + id).css("pointer events: default;");
       $('#' + id).attr("disabled", false);
+    });
+    $(".persistButton").each(function(index, id) {
+      $(this).css("pointer events: default;");
+      $(this).attr("disabled", false);
     });
     $("#spectate").hide();
     $("#drive").show();
@@ -567,7 +576,7 @@ function makeTooltips(className) {
     if ($(this).attr('id') ) {
       var tooltipId = 'tooltip_' + simpleClassName + "_" + index;
       var tooltipTextId = 'tooltip_text_' + simpleClassName + "_" + index;
-      var tooltip = "<div class='tooltip' id='" + tooltipId + "' persist='false'><div id='persistButton'><input type='checkbox' onclick=persistTooltip('" + tooltipId + "');>persist</div><div><textarea id='" + tooltipTextId +"'> </textarea></div></div>";
+      var tooltip = "<div class='tooltip' id='" + tooltipId + "' persist='false'><div class='persistButton'><input type='checkbox' onclick=persistTooltip('" + tooltipId + "');>persist</div><div><textarea id='" + tooltipTextId +"'> </textarea></div></div>";
       $(tooltip).insertAfter($(this));
       $('#'+tooltipId).hide();
 

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -641,6 +641,7 @@ function hcalOnLoad() {
     removeduplicatecheckbox('USE_PRIMARY_TCDS');
     getfullpath();
     showsupervisorerror();
+    showErrorTable();
     makedropdown($('#LOCAL_RUNKEY_MAP').text(), $('#AVAILABLE_LOCAL_RUNKEYS').text());
     giveEventCheckboxOnclick();
     onClickCommandParameterCheckBox();

--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -55,9 +55,10 @@ function showErrorTable() {
       errTableHTML += "<td class='errAppnameHeader'>App Name</td><td class='errMessageHeader'>Message</td></tr>";
       for(var i=0; i<errVector.length; i++) {
         errTableHTML += "<tr class='errRow'>";
-        //errTableHTML += "<td class='errTimestamp'>" + errVector[i]["timestamp"] + "</td>";
-        errTableHTML += "<td class='errAppname'>"   + errVector[i]["app"]       + "</td>";
-        errTableHTML += "<td class='errMessage'>"   + errVector[i]["message"]   + "</td></tr>";
+        //errTableHTML += "<td class='errTimestamp'>" +      errVector[i]["timestamp"] + "</td>";
+        errTableHTML += "<td class='errAppname'><a href='" + errVector[i]["URI"] + "'>";
+        errTableHTML +=                                      errVector[i]["app"]       + "</a></td>";
+        errTableHTML += "<td class='errMessage'>"   +        errVector[i]["message"]   + "</td></tr>";
       }
       errTableHTML += "</table>";
       $("#errMapError").html(errTableHTML);

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2707,13 +2707,18 @@ public class HCALEventHandler extends UserEventHandler {
           for (String s : AppURIString){           AppURIVector.add(new StringT(s));        }
 
           List<XdaqApplication> tcdsList = new ArrayList<XdaqApplication>();
-          for (StringT appName : AppNameVector){
-            StringT appURI = AppURIVector.get( AppNameVector.indexOf(appName));
+          for (StringT appURI : AppURIVector){
             // Check URI to see if this is a TCDS app
             if (appURI.contains("tcds-control")){
               String QRtype = "rcms.fm.resource.qualifiedresource.XdaqApplication";
-              String tcdsname = appName.getString();
+              String tcdsname = "";
               String tcdsURI  = appURI.getString();
+              if (tcdsURI.contains("lid=30")){ tcdsname = "tcds::ici::ICIController";}
+              else if (tcdsURI.contains("lid=50")){ tcdsname = "tcds::pi::PIController";}
+              else if (tcdsURI.contains("lid=20")){ tcdsname = "tcds::lpm::LPMController";}
+              else {
+                logger.error("[HCAL "+ functionManager.FMname+"] FillTCDScontainersWithURI(): found this TCDS app with a strange URI="+ tcdsURI);
+              }
               int sessionId = ((IntegerT)functionManager.getParameterSet().get("SID").getValue()).getInteger();
               XdaqApplicationResource tcdsAppRsc = new XdaqApplicationResource(functionManager.getGroup().getDirectory(), tcdsname, tcdsURI , QRtype, null, null);
               XdaqApplication  tcdsApp = new XdaqApplication(tcdsAppRsc);
@@ -2721,8 +2726,12 @@ public class HCALEventHandler extends UserEventHandler {
             }
           }
           functionManager.containerTCDSControllers = new XdaqApplicationContainer(tcdsList);
-          logger.info("FillTCDScontainersWithURI(): found following TCDS apps");
-          PrintQRnames(functionManager.containerTCDSControllers);
+          logger.info("[HCAL "+ functionManager.FMname+"] FillTCDScontainersWithURI(): found following TCDS apps");
+          String info=" \n ";
+          for (QualifiedResource app : functionManager.containerTCDSControllers.getQualifiedResourceList()){
+            info += app.getName()+ " URI = " + app.getURI().toString() +" \n";
+          }
+          logger.info(info);
       }
       catch (XDAQTimeoutException e) {
 				String errMessage = "[HCAL " + functionManager.FMname + "] Error! XDAQTimeoutException: FillTCDScontainersWIthURI(): couldn't get xdaq parameters";

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -864,7 +864,9 @@ public class HCALFunctionManager extends UserFunctionManager {
       //logger.info("[HCAL LVL2 " + FMname + "] haltTCDSControllers: Halting with SID= "+sessionId+" and RCMSURL = "+rcmsStateListenerURL);
 
       List<XdaqApplicationContainer> tcdsContainerList = new ArrayList<XdaqApplicationContainer>();
-      tcdsContainerList.add( containerTCDSControllers);
+      if(containerTCDSControllers !=null){
+        tcdsContainerList.add( containerTCDSControllers);
+      }
       for (XdaqApplicationContainer tcdsContainer : tcdsContainerList){
         if (!tcdsContainer.isEmpty()) {
           if(isServiceApp){

--- a/src/rcms/fm/app/level1/HCALFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALFunctionManager.java
@@ -874,7 +874,7 @@ public class HCALFunctionManager extends UserFunctionManager {
           }
           else{
             for(XdaqApplication tcdsApp : tcdsContainer.getApplications()){
-              logger.info("[HCAL LVL2 " + FMname + "] haltTCDSControllers: Sending halt to "+tcdsApp.getName()+" with SID="+sessionId+" and RCMSURL = "+rcmsStateListenerURL);
+              logger.info("[HCAL LVL2 " + FMname + "] haltTCDSControllers: Sending halt to "+tcdsApp.getName()+" with SID="+sessionId+" , RCMSURL = "+rcmsStateListenerURL+ ", URI="+tcdsApp.getURI().toString());
               tcdsApp.execute(HCALInputs.HALT,Integer.toString(sessionId),rcmsStateListenerURL);
             }
           }

--- a/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
@@ -104,7 +104,10 @@ public class HCALlevelTwoFunctionManager extends HCALFunctionManager {
                 errMap.put( "app", new StringT("("+partition+")"+nameAndCrate));
               }
               else{
-                errMap.put( "app", new StringT("("+partition+") "+ errAppName));
+                //explicitly state instance number for non-crate app
+                String nameOnly = errAppName.getString().split(":")[0];
+                String nameAndInstance = nameOnly + " instance " + errAppCratr;ppName.getString().split(":")[1];
+                errMap.put( "app", new StringT("("+partition+") "+ nameAndInstance));
               }
               xDAQ_err_msg.add(errMap);
             }

--- a/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
@@ -106,7 +106,7 @@ public class HCALlevelTwoFunctionManager extends HCALFunctionManager {
               else{
                 //explicitly state instance number for non-crate app
                 String nameOnly = errAppName.getString().split(":")[0];
-                String nameAndInstance = nameOnly + " instance " + errAppCratr;ppName.getString().split(":")[1];
+                String nameAndInstance = nameOnly + " instance " + errAppName.getString().split(":")[1];
                 errMap.put( "app", new StringT("("+partition+") "+ nameAndInstance));
               }
               xDAQ_err_msg.add(errMap);


### PR DESCRIPTION
@jhakala
With hcos MR 228, we can add URL to the hyperdaq of the error apps.
Can you add the link to the text in the GUI as well?
I'm sure those users with "save me a few clicks" spirit will appreciate that.
Feel free to test it at 904 daq01, the supervisor patched there has this `HandledApp` vector