### PR TITLE
Simplify QG navigation

### DIFF
--- a/gui/js/hcalui.js
+++ b/gui/js/hcalui.js
@@ -241,7 +241,7 @@ function makedropdown(availableRunConfigs, availableLocalRunKeys) {
         if (runConfigMap[localRunKeysArray[i]].hasOwnProperty('singlePartitionFM')) { singlePartitionFM=runConfigMap[localRunKeysArray[i]].singlePartitionFM; }
         eventsToTake = "default";
         if (runConfigMap[localRunKeysArray[i]].hasOwnProperty('eventsToTake')) { eventsToTake=runConfigMap[localRunKeysArray[i]].eventsToTake; }
-          dropdownoption = dropdownoption + "<option value='" + runConfigMap[localRunKeysArray[i]].snippet + "' maskedresources='" + runConfigMap[localRunKeysArray[i]].maskedapps +"' maskedFM='" + maskedFM + "' + singlePartitionFM='" + singlePartitionFM+ "' eventsToTake='" + eventsToTake+ "' ";
+          dropdownoption = dropdownoption + "<option value='" + runConfigMap[localRunKeysArray[i]].snippet + "' maskedresources='" + runConfigMap[localRunKeysArray[i]].maskedapps + "' maskedcrates='" + runConfigMap[localRunKeysArray[i]].maskedcrates +"' maskedFM='" + maskedFM + "' + singlePartitionFM='" + singlePartitionFM+ "' eventsToTake='" + eventsToTake+ "' ";
 
         if (localRunKeysArray[i] != $("#LOCAL_RUNKEY_SELECTED").val()) {
           dropdownoption = dropdownoption + "' >" + localRunKeysArray[i] + "</option>";
@@ -286,6 +286,10 @@ function fillMask() {
     var userXMLmaskedApps = $('#dropdown option:selected').attr("maskedresources").split("|");
     for (var i = 0; i < userXMLmaskedApps.length; i++) {
       if (userXMLmaskedApps[i] != "") finalMasks.push(userXMLmaskedApps[i]);
+    }
+    var userXMLmaskedCrates = $('#dropdown option:selected').attr("maskedcrates").split("|");
+    for (var i = 0; i < userXMLmaskedCrates.length; i++) {
+      if (userXMLmaskedCrates[i] != "") finalMasks.push("physicalCrate_" + userXMLmaskedCrates[i]);
     }
     $('#MASKED_RESOURCES').val(JSON.stringify(finalMasks));
     var masksToShow = "[";

--- a/schema/grandmaster.xsd
+++ b/schema/grandmaster.xsd
@@ -40,6 +40,7 @@
                   <xs:attribute type="xs:string" name="maskedFM" use="optional"/>
                   <xs:attribute type="xs:string" name="singlePartitionFM" use="optional"/>
                   <xs:attribute type="xs:string" name="maskedapps" use="optional"/>
+                  <xs:attribute type="xs:string" name="maskedcrates" use="optional"/>
                 </xs:complexType>
               </xs:element>
             </xs:sequence>

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -35,6 +35,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.Text;
 
+import rcms.fm.app.level1.HCALqgMapper.abstractQGmapReader;
 import rcms.fm.fw.StateEnteredEvent;
 import rcms.fm.fw.parameter.Parameter;
 import rcms.fm.fw.parameter.FunctionManagerParameter;
@@ -88,6 +89,7 @@ public class HCALEventHandler extends UserEventHandler {
   protected HCALFunctionManager functionManager = null;
   static RCMSLogger logger = new RCMSLogger(HCALEventHandler.class);
   public HCALxmlHandler xmlHandler = null;
+  public abstractQGmapReader qgMapper = null;
   public LogSessionConnector logSessionConnector;  // Connector for logsession DB
 
   // Essential xdaq stuff

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -39,11 +39,11 @@ public class HCALMasker {
 
   public HCALMasker(HCALFunctionManager parentFunctionManager, level1qgMapper mapper) {
     this.logger = new RCMSLogger(HCALFunctionManager.class);
-    logger.warn("Constructing masker.");
+    logger.info("Constructing masker.");
     this.functionManager = parentFunctionManager;
     xmlHandler = new HCALxmlHandler(parentFunctionManager);
     this.mapper = mapper;
-    logger.warn("Done constructing masker.");
+    logger.info("Done constructing masker.");
   }
 
   protected Map<String, Boolean> isEvmTrigCandidate(List<Resource> level2Children) {
@@ -52,7 +52,6 @@ public class HCALMasker {
     boolean hasAnEventBuilder = false;
     boolean hasAnFU = false;
     VectorT<StringT> maskedRss =  (VectorT<StringT>)functionManager.getHCALparameterSet().get("MASKED_RESOURCES").getValue();
-    logger.warn(maskedRss.toString());
     StringT[] maskedRssArray = maskedRss.toArray(new StringT[maskedRss.size()]);
 
     for (Resource level2resource : level2Children) {

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -116,15 +116,11 @@ public class HCALMasker {
         for(StringT MaskedApp : maskedRssArray){
           for(Resource level2resource: level2Children){
             if( level2resource.getName().equals(MaskedApp.getString()) && level2resource.getQualifiedResourceType().contains("XdaqExecutive") ){
-              logger.warn("[JohnLogExecMask] attempting to mask: " + level2resource.getName());
-              for (StringT execApp : mapper.getAppsOfExec(level2resource.getName()).getVector())
+              for (StringT execApp : mapper.getAppsOfExec(level2resource.getName()).getVector()) {
                 if (! maskedRss.contains(execApp)){
-                  logger.warn("[JohnLogExecMask] adding app: " + execApp.getString());
                   maskedRss.add(execApp);
                 }
-                else {
-                  logger.warn("[JohnLogExecMask] app " + execApp.getString() + " was already found in MASKED_RESOURCES, not double-writing.");
-                }
+              }
             }
           }
         }
@@ -400,14 +396,12 @@ public class HCALMasker {
 
     StringT[] maskedResourcesArray = allMaskedResources.toArray(new StringT[allMaskedResources.size()]);
     for (StringT maskedResource : maskedResourcesArray) {
-      logger.warn("[JohnLogCrateMask] working on masked resource: " + maskedResource);
       if (maskedResource.getString().contains("physicalCrate")) {
-        logger.warn("[JohnLogCrateMask] found physicalCrate: " + maskedResource);
         try {
           if (!Arrays.asList(maskedResourcesArray).contains(maskedResource.getString())) {
             allMaskedResources.add(new StringT(mapper.getExecOfCrate(Integer.parseInt(maskedResource.getString().split("_")[1]))));
+            logger.warn("[HCAL " + functionManager.FMname + "]: Found " + maskedResource + " in masking list, therefore added " + mapper.getExecOfCrate(Integer.parseInt(maskedResource.getString().split("_")[1])) + " to MASKED_RESOURCES");
           }
-          logger.warn("[JohnLogCrateMask] added " + mapper.getExecOfCrate(Integer.parseInt(maskedResource.getString().split("_")[1])) + " to MASKED_RESOURCES");
         }
         catch (NumberFormatException e) {
           throw new UserActionException("Could not extract a valid crate number from requested maskedcrate" + e.getMessage());

--- a/src/rcms/fm/app/level1/HCALMasker.java
+++ b/src/rcms/fm/app/level1/HCALMasker.java
@@ -388,4 +388,23 @@ public class HCALMasker {
       functionManager.getHCALparameterSet().put(new FunctionManagerParameter<VectorT<StringT>>("MASK_SUMMARY", maskedFMsVector));
     }
   }
+
+  public void setMaskedCrates() throws UserActionException {
+        VectorT<StringT> allMaskedResources =  (VectorT<StringT>)functionManager.getHCALparameterSet().get("MASKED_RESOURCES").getValue();
+        for (StringT maskedResource : allMaskedResources) {
+          if (maskedResource.getString().contains("physicalCrate")) {
+            try {
+              allMaskedResources.add(new StringT(mapper.getExecOfCrate(Integer.parseInt(maskedResource.getString().split("_")[1]))));
+            }
+            catch (NumberFormatException e) {
+              throw new UserActionException("Could not extract a valid crate number from requested maskedcrate" + e.getMessage());
+            }
+            catch (UserActionException e) {
+              throw new UserActionException("Problem setting the masked crates" + e.getMessage());
+            }
+            
+          }
+        }
+        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<VectorT<StringT>>("MASKED_RESOURCES", allMaskedResources));
+  }
 }

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -117,6 +117,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 		this.put( new FunctionManagerParameter<VectorT<StringT>> ("MASK_SUMMARY"             ,  new VectorT<StringT>()    ) );  // Summary of masked FMs for user understandability
 		this.put( new FunctionManagerParameter<VectorT<StringT>> ("EMPTY_FMS"                ,  new VectorT<StringT>()    ) );  // LV2 FMs without XDAQs
 		this.put( new FunctionManagerParameter<VectorT<MapT<StringT>> > ("XDAQ_ERR_MSG"      ,  new VectorT<MapT<StringT>>()));  // Vector to contain XDAQ app err messages: < <App1:Err>,<App2:Err>,... >
+		this.put( new FunctionManagerParameter<MapT<MapT<MapT<VectorT<StringT>>>> > ("QG_MAP"      ,  new MapT<MapT<MapT<VectorT<StringT>>>>()));  // map of config's QG, see comments in HCALqgMapper
 	}
 
 	public static HCALParameters getInstance() {

--- a/src/rcms/fm/app/level1/HCALStateMachineDefinition.java
+++ b/src/rcms/fm/app/level1/HCALStateMachineDefinition.java
@@ -184,7 +184,6 @@ public class HCALStateMachineDefinition extends UserStateMachineDefinition {
     CommandParameter<BooleanT> configureUSE_RESET_FOR_RECOVER    =  new CommandParameter<BooleanT> ("USE_RESET_FOR_RECOVER"   ,  new BooleanT(true)  );
     CommandParameter<VectorT<StringT>>  configureMASKED_RESOURCES         =  new CommandParameter<VectorT<StringT>>  ("MASKED_RESOURCES"        ,  new VectorT<StringT>()     );
     CommandParameter<VectorT<StringT>>  configureAVAILABLE_RESOURCES      =  new CommandParameter<VectorT<StringT>>  ("AVAILABLE_RESOURCES"     ,  new VectorT<StringT>()     );
-    CommandParameter<MapT<MapT<MapT<VectorT<StringT>>>>>  configureQG_MAP   =  new CommandParameter<MapT<MapT<MapT<VectorT<StringT>>>>>  ("QG_MAP"     ,  new MapT<MapT<MapT<VectorT<StringT>>>>()     );
 
     // define parameter set
     ParameterSet<CommandParameter> configureParameters = new ParameterSet<CommandParameter>();
@@ -215,7 +214,6 @@ public class HCALStateMachineDefinition extends UserStateMachineDefinition {
       configureParameters.add(configureRU_INSTANCE);
       configureParameters.add(configureLPM_SUPERVISOR);
       configureParameters.add(configureEVM_TRIG_FM);
-      configureParameters.add(configureQG_MAP);
     } catch (ParameterException nothing) {
       // Throws an exception if a parameter is duplicate
       throw new StateMachineDefinitionException( "Could not add to configureParameters. Duplicate Parameter?", nothing );

--- a/src/rcms/fm/app/level1/HCALStateMachineDefinition.java
+++ b/src/rcms/fm/app/level1/HCALStateMachineDefinition.java
@@ -5,6 +5,7 @@ import rcms.fm.fw.parameter.CommandParameter;
 import rcms.fm.fw.parameter.ParameterException;
 import rcms.fm.fw.parameter.ParameterSet;
 import rcms.fm.fw.parameter.type.IntegerT;
+import rcms.fm.fw.parameter.type.MapT;
 import rcms.fm.fw.parameter.type.BooleanT;
 import rcms.fm.fw.parameter.type.StringT;
 import rcms.fm.fw.parameter.type.VectorT;
@@ -183,6 +184,7 @@ public class HCALStateMachineDefinition extends UserStateMachineDefinition {
     CommandParameter<BooleanT> configureUSE_RESET_FOR_RECOVER    =  new CommandParameter<BooleanT> ("USE_RESET_FOR_RECOVER"   ,  new BooleanT(true)  );
     CommandParameter<VectorT<StringT>>  configureMASKED_RESOURCES         =  new CommandParameter<VectorT<StringT>>  ("MASKED_RESOURCES"        ,  new VectorT<StringT>()     );
     CommandParameter<VectorT<StringT>>  configureAVAILABLE_RESOURCES      =  new CommandParameter<VectorT<StringT>>  ("AVAILABLE_RESOURCES"     ,  new VectorT<StringT>()     );
+    CommandParameter<MapT<MapT<MapT<VectorT<StringT>>>>>  configureQG_MAP   =  new CommandParameter<MapT<MapT<MapT<VectorT<StringT>>>>>  ("QG_MAP"     ,  new MapT<MapT<MapT<VectorT<StringT>>>>()     );
 
     // define parameter set
     ParameterSet<CommandParameter> configureParameters = new ParameterSet<CommandParameter>();
@@ -213,6 +215,7 @@ public class HCALStateMachineDefinition extends UserStateMachineDefinition {
       configureParameters.add(configureRU_INSTANCE);
       configureParameters.add(configureLPM_SUPERVISOR);
       configureParameters.add(configureEVM_TRIG_FM);
+      configureParameters.add(configureQG_MAP);
     } catch (ParameterException nothing) {
       // Throws an exception if a parameter is duplicate
       throw new StateMachineDefinitionException( "Could not add to configureParameters. Duplicate Parameter?", nothing );

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -87,6 +87,8 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         logger.warn("[JohnLogQG] crate of hcal::DTCManager_6: " + mapper.getCrateOfApp("hcal::DTCManager_6"));
         logger.warn("[JohnLogQG] crate of hcal::uHTRManager_3: " + mapper.getCrateOfApp("hcal::uHTRManager_3"));
         logger.warn("[JohnLogQG] crate of hcalHTRManager_0: " + mapper.getCrateOfApp("hcalHTRManager_0", new StringT("HCAL_HO904")));
+        logger.warn("[JohnLogQG] apps of exec Executive_9: " + mapper.getAppsOfExec("Executive_9"));
+        logger.warn("[JohnLogQG] apps of crate 62: " + mapper.getAppsOfCrate("62"));
       }
       catch (UserActionException e1) {
         // TODO Auto-generated catch block

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -217,6 +217,9 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           if ( ((Element)nodes.item(i)).hasAttribute("maskedFM")){
             RunKeySetting.put(new StringT("maskedFM")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("maskedFM"  ).getNodeValue()));
           }
+          if ( ((Element)nodes.item(i)).hasAttribute("maskedcrates")){
+            RunKeySetting.put(new StringT("maskedcrates")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("maskedcrates"  ).getNodeValue()));
+          }
           if ( ((Element)nodes.item(i)).hasAttribute("singlePartitionFM")){
             RunKeySetting.put(new StringT("singlePartitionFM")  ,new StringT(nodes.item(i).getAttributes().getNamedItem("singlePartitionFM").getNodeValue()));
           }
@@ -1675,6 +1678,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
           for (String app:maskedapps){
             MaskedResources.add(new StringT(app));
           }
+          // XXX JCH what about maskedcrates? should that be used in global?
         }
         logger.info("[HCAL "+functionManager.FMname+" FillMaskedResources: Filled MASKED_RESOURCES from runkey:" + MaskedResources.toString());
         functionManager.getHCALparameterSet().put(new FunctionManagerParameter<VectorT<StringT>>("MASKED_RESOURCES",MaskedResources));
@@ -1683,6 +1687,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
   }
 
   public void checkMaskedappsFormat() throws UserActionException{
+    // TODO JCH should something similar be done with maskedcrates?
     StringT runkeyName                 = (StringT) functionManager.getHCALparameterSet().get("LOCAL_RUNKEY_SELECTED").getValue();
     MapT<MapT<StringT>> LocalRunKeyMap = (MapT<MapT<StringT>>)functionManager.getHCALparameterSet().get("LOCAL_RUNKEY_MAP").getValue();
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -78,6 +78,14 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
     super.init();  // this method calls the base class init and has to be called _after_ the getting of the functionManager
 
 
+      try {
+        mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource(), functionManager.getQualifiedGroup());
+        logger.warn("[JohnLogQG] " + mapper.getMap().toString());
+      }
+      catch (UserActionException e1) {
+        // TODO Auto-generated catch block
+        logger.error("[HCAL " + functionManager.FMname + "]: got an error when trying to map the QG: " + e1.getMessage());
+      }
     // Get the CfgCVSBasePath in the userXML
     {
       String DefaultCfgCVSBasePath = "/nfshome0/hcalcfg/cvs/RevHistory/";
@@ -244,14 +252,6 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       String MastersnippetSelected = "";
       String LocalRunkeySelected = "";
 
-      try {
-        mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource(), functionManager.getQualifiedGroup());
-        logger.warn("[JohnLogQG] " + mapper.getMap().toString());
-      }
-      catch (UserActionException e1) {
-        // TODO Auto-generated catch block
-        logger.error("[HCAL " + functionManager.FMname + "]: got an error when trying to map the QG: " + e1.getMessage());
-      }
       // get the parameters of the command
       ParameterSet<CommandParameter> parameterSet = getUserFunctionManager().getLastInput().getParameterSet();
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -363,7 +363,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       
       //Fill MASKED_RESOURCES from runkey if not already set by GUI, i.e. global or minidaq run
       FillMaskedResources();
-      masker.setMaskedCrates();
+      //masker.setMaskedCrates();
       masker.pickEvmTrig();
       masker.setMaskedFMs();
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -82,11 +82,11 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource(), functionManager.getQualifiedGroup());
         // testing
         logger.warn("[JohnLogQG] " + mapper.getMap().toString());
-        logger.warn("[JohnLogQG] executive of crate 52" + mapper.getExecOfCrate(52));
-        logger.warn("[JohnLogQG] executive of crate 60" + mapper.getExecOfCrate(60));
-        logger.warn("[JohnLogQG] crate of hcal::DTCManager_6" + mapper.getCrateOfApp("hcal::DTCManager_6"));
-        logger.warn("[JohnLogQG] crate of hcal::uHTRManager_3" + mapper.getCrateOfApp("hcal::uHTRManager_3"));
-        logger.warn("[JohnLogQG] crate of hcalHTRManager_0" + mapper.getCrateOfApp("hcalHTRManager_0", new StringT("HCAL_HO904")));
+        logger.warn("[JohnLogQG] executive of crate 52: " + mapper.getExecOfCrate(52));
+        logger.warn("[JohnLogQG] executive of crate 61: " + mapper.getExecOfCrate(61));
+        logger.warn("[JohnLogQG] crate of hcal::DTCManager_6: " + mapper.getCrateOfApp("hcal::DTCManager_6"));
+        logger.warn("[JohnLogQG] crate of hcal::uHTRManager_3: " + mapper.getCrateOfApp("hcal::uHTRManager_3"));
+        logger.warn("[JohnLogQG] crate of hcalHTRManager_0: " + mapper.getCrateOfApp("hcalHTRManager_0", new StringT("HCAL_HO904")));
       }
       catch (UserActionException e1) {
         // TODO Auto-generated catch block

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -73,10 +73,8 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
 
     functionManager = (HCALFunctionManager) getUserFunctionManager();
     xmlHandler = new HCALxmlHandler(this.functionManager);
-    masker = new HCALMasker(this.functionManager);
 
     super.init();  // this method calls the base class init and has to be called _after_ the getting of the functionManager
-
 
       try {
         mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource(), functionManager.getQualifiedGroup());
@@ -94,6 +92,8 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         // TODO Auto-generated catch block
         logger.error("[HCAL " + functionManager.FMname + "]: got an error when trying to map the QG: " + e1.getMessage());
       }
+    masker = new HCALMasker(this.functionManager, this.mapper);
+
     // Get the CfgCVSBasePath in the userXML
     {
       String DefaultCfgCVSBasePath = "/nfshome0/hcalcfg/cvs/RevHistory/";

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -19,6 +19,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.DOMException;
 
+import rcms.fm.app.level1.HCALqgMapper.level1qgMapper;
 import rcms.fm.fw.StateEnteredEvent;
 import rcms.fm.fw.parameter.CommandParameter;
 import rcms.fm.fw.parameter.FunctionManagerParameter;
@@ -57,6 +58,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
   static RCMSLogger logger = new RCMSLogger(HCALlevelOneEventHandler.class);
   public HCALxmlHandler xmlHandler = null;
   public HCALMasker masker = null;
+  public HCALqgMapper.level1qgMapper mapper = null;
   private AlarmerWatchThread alarmerthread = null;
 
   private Double  progress           = 0.0;
@@ -72,6 +74,13 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
     functionManager = (HCALFunctionManager) getUserFunctionManager();
     xmlHandler = new HCALxmlHandler(this.functionManager);
     masker = new HCALMasker(this.functionManager);
+    try {
+      mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource());
+    }
+    catch (UserActionException e1) {
+      // TODO Auto-generated catch block
+      logger.error("[HCAL " + functionManager.FMname + "]: got an error when trying to map the QG: " + e1.getMessage());
+    }
 
     super.init();  // this method calls the base class init and has to be called _after_ the getting of the functionManager
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -80,7 +80,13 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
 
       try {
         mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource(), functionManager.getQualifiedGroup());
+        // testing
         logger.warn("[JohnLogQG] " + mapper.getMap().toString());
+        logger.warn("[JohnLogQG] executive of crate 52" + mapper.getExecOfCrate(52));
+        logger.warn("[JohnLogQG] executive of crate 60" + mapper.getExecOfCrate(60));
+        logger.warn("[JohnLogQG] crate of hcal::DTCManager_6" + mapper.getCrateOfApp("hcal::DTCManager_6"));
+        logger.warn("[JohnLogQG] crate of hcal::uHTRManager_3" + mapper.getCrateOfApp("hcal::uHTRManager_3"));
+        logger.warn("[JohnLogQG] crate of hcalHTRManager_0" + mapper.getCrateOfApp("hcalHTRManager_0", new StringT("HCAL_HO904")));
       }
       catch (UserActionException e1) {
         // TODO Auto-generated catch block

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -363,6 +363,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
       
       //Fill MASKED_RESOURCES from runkey if not already set by GUI, i.e. global or minidaq run
       FillMaskedResources();
+      masker.setMaskedCrates();
       masker.pickEvmTrig();
       masker.setMaskedFMs();
 

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -77,14 +77,6 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
 
     super.init();  // this method calls the base class init and has to be called _after_ the getting of the functionManager
 
-    try {
-      mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource(), functionManager.getQualifiedGroup());
-      logger.warn("[JohnLogQG] " + mapper.getMap().toString());
-    }
-    catch (UserActionException e1) {
-      // TODO Auto-generated catch block
-      logger.error("[HCAL " + functionManager.FMname + "]: got an error when trying to map the QG: " + e1.getMessage());
-    }
 
     // Get the CfgCVSBasePath in the userXML
     {
@@ -251,6 +243,15 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
     if (obj instanceof StateEnteredEvent) {
       String MastersnippetSelected = "";
       String LocalRunkeySelected = "";
+
+      try {
+        mapper = new HCALqgMapper().new level1qgMapper(functionManager.getGroup().getThisResource(), functionManager.getQualifiedGroup());
+        logger.warn("[JohnLogQG] " + mapper.getMap().toString());
+      }
+      catch (UserActionException e1) {
+        // TODO Auto-generated catch block
+        logger.error("[HCAL " + functionManager.FMname + "]: got an error when trying to map the QG: " + e1.getMessage());
+      }
       // get the parameters of the command
       ParameterSet<CommandParameter> parameterSet = getUserFunctionManager().getLastInput().getParameterSet();
 

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -54,9 +54,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
     xmlHandler = new HCALxmlHandler(this.functionManager);
     super.init();
 
-    qgMapper = new HCALqgMapper().new level2qgMapParser();
-      
-
     logger.debug("[HCAL LVL2] init() called: functionManager = " + functionManager );
   }
 
@@ -284,7 +281,7 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         MapT<MapT<MapT<VectorT<StringT>>>> qgMap = ((MapT<MapT<MapT<VectorT<StringT>>>>)parameterSet.get("QG_MAP").getValue());
         logger.info("[HCAL LVL2 " + functionManager.FMname + "] Received QG map: "+qgMap.toString());
         functionManager.getParameterSet().put(new FunctionManagerParameter<MapT<MapT<MapT<VectorT<StringT>>>>>("QG_MAP", qgMap));
-        ((level2qgMapParser) qgMapper).setMap(qgMap); 
+        qgMapper = new HCALqgMapper().new level2qgMapParser(qgMap); 
       }
       else{
         logger.error("[HCAL LVL2 " + functionManager.FMname + "] initAction: Did not receive QG_MAP during initAction");

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -7,7 +7,7 @@ import java.util.List;
 import net.hep.cms.xdaqctl.XDAQException;
 import net.hep.cms.xdaqctl.XDAQTimeoutException;
 import net.hep.cms.xdaqctl.XDAQMessageException;
-
+import rcms.fm.app.level1.HCALqgMapper.level2qgMapParser;
 import rcms.fm.fw.StateEnteredEvent;
 import rcms.fm.fw.parameter.CommandParameter;
 import rcms.fm.fw.parameter.FunctionManagerParameter;
@@ -53,6 +53,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
     functionManager = (HCALFunctionManager) getUserFunctionManager();
     xmlHandler = new HCALxmlHandler(this.functionManager);
     super.init();
+
+    qgMapper = new HCALqgMapper().new level2qgMapParser();
       
 
     logger.debug("[HCAL LVL2] init() called: functionManager = " + functionManager );
@@ -277,6 +279,15 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       }
       else{
         logger.error("[HCAL LVL2 " + functionManager.FMname + "] initAction: Did not receive LOCAL_RUNKEY_MAP during initAction");
+      }
+      if( parameterSet.get("QG_MAP") != null){
+        MapT<MapT<MapT<VectorT<StringT>>>> qgMap = ((MapT<MapT<MapT<VectorT<StringT>>>>)parameterSet.get("QG_MAP").getValue());
+        logger.info("[HCAL LVL2 " + functionManager.FMname + "] Received QG map: "+qgMap.toString());
+        functionManager.getParameterSet().put(new FunctionManagerParameter<MapT<MapT<MapT<VectorT<StringT>>>>>("QG_MAP", qgMap));
+        ((level2qgMapParser) qgMapper).setMap(qgMap); 
+      }
+      else{
+        logger.error("[HCAL LVL2 " + functionManager.FMname + "] initAction: Did not receive QG_MAP during initAction");
       }
       // give the RunType to the controlling FM
       functionManager.RunType = RunType;

--- a/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
@@ -97,7 +97,7 @@ public class HCALlevelTwoFunctionManager extends HCALFunctionManager {
               //    errAppCrate = new StringT(errAppPortNumber.substring(3));
               //  }
               //}
-              errAppCrate = new StringT(theEventHandler.qgMapper.getCrateOfApp(errAppName.getString().replace(":", "_")));
+              errAppCrate = new StringT(theEventHandler.qgMapper.getCrateOfApp(errAppName.getString().replaceAll("(?<!:):(?!:)", "_")));
               // Replace instance number with crate number
               if (!errAppCrate.equals("non-crate")){
                 String[] nameSplit= errAppName.getString().split(":");

--- a/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoFunctionManager.java
@@ -88,17 +88,18 @@ public class HCALlevelTwoFunctionManager extends HCALFunctionManager {
                   errMap.put("URI", errAppURI) ;
                 }
               }
-              // Extract crate number from URI
-              if (errAppURI.length()>0){
-                // e.g. URI = http://hcal904daq01.cms904:39100/urn:xdaq-application:lid=53
-                String errAppPortNumber  = errAppURI.getString().split("/")[2].split(":")[1];
-                // 3 digit in port number = isCrate boolean
-                if (String.valueOf(errAppPortNumber.charAt(2)).equals("1")){
-                  errAppCrate = new StringT(errAppPortNumber.substring(3));
-                }
-              }
+              //// Extract crate number from URI
+              //if (errAppURI.length()>0){
+              //  // e.g. URI = http://hcal904daq01.cms904:39100/urn:xdaq-application:lid=53
+              //  String errAppPortNumber  = errAppURI.getString().split("/")[2].split(":")[1];
+              //  // 3 digit in port number = isCrate boolean
+              //  if (String.valueOf(errAppPortNumber.charAt(2)).equals("1")){
+              //    errAppCrate = new StringT(errAppPortNumber.substring(3));
+              //  }
+              //}
+              errAppCrate = new StringT(theEventHandler.qgMapper.getCrateOfApp(errAppName.getString().replace(":", "_")));
               // Replace instance number with crate number
-              if (!errAppCrate.equals("")){
+              if (!errAppCrate.equals("non-crate")){
                 String[] nameSplit= errAppName.getString().split(":");
                 String nameOnly   = "";
                 //Remove the last part of ":" split, which is the instance

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -116,7 +116,8 @@ public class HCALqgMapper {
       List<QualifiedResource> l2FMlist = qg.seekQualifiedResourcesOfType(new FunctionManager());
       for (QualifiedResource qr: l2FMlist) {
         try {
-          level2qgMapper level2mapper = new level2qgMapper(qr.getResource(), qr.getQualifiedGroup());
+          QualifiedGroup level2group = ((FunctionManager)qr).getQualifiedGroup();
+          level2qgMapper level2mapper = new level2qgMapper(qr.getResource(), level2group);
           // TODO: fix this
           // level2qgMapper level2mapper = new level2qgMapper(qr.getResource(), qr.getChildrenResources());
           MapT<MapT<VectorT<StringT>>> level2map = (MapT<MapT<VectorT<StringT>>>) level2mapper.getMap();

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -204,11 +204,12 @@ public class HCALqgMapper {
      * @throws UserActionException if it fails to find the executive
      */
     public VectorT<StringT> getAppsOfExec(String execName) throws UserActionException {
-      MapT<MapT<MapT<VectorT<StringT>>>> l1qgMap = (MapT<MapT<MapT<VectorT<StringT>>>>) qgMap.getMap();
-      for (StringT execKey : l1qgMap.getMap().keySet()) {
-        for (MapT<VectorT<StringT>> crateMap : l1qgMap.getMap().get(execKey).getMap().values()) {
-          for (VectorT<StringT> appList : crateMap.getMap().values()) {
+      for (ParameterType<?> l2Map : qgMap.getMap().values()) {
+        MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) l2Map;
+        for (StringT execKey : execMap.getMap().keySet()) {
+          for (VectorT<StringT> appList : execMap.getMap().get(execKey).getMap().values()) {
             if (execKey.getString().equals(execName)) {
+              logger.warn("[JohnLogQG] execKey.getString(): " + execKey.getString());
               return appList;
             }
           }

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -55,23 +55,20 @@ public class HCALqgMapper {
       MapT<MapT<VectorT<StringT>>> execMap = new MapT<MapT<VectorT<StringT>>>();
       MapT<VectorT<StringT>> crateMap = new MapT<VectorT<StringT>>();
       String crateNumber = "N/A"; // if it is not an executive corresponding to the crate
-      VectorT appList = new VectorT();
       String execName = "";
+      VectorT appList = new VectorT();
       for(Resource qr : level2childList) {
         // this list has apps and execs mixed together
-        logger.warn("l2 outer loop: qr: " + qr.getName());
+        crateNumber = "N/A"; // if it is not an executive corresponding to the crate
+        execName = "NoExecName";
         if (qr.getQualifiedResourceType().contains("Executive")){
           execName = qr.getName();
-          execMap = new MapT<MapT<VectorT<StringT>>>();
-          crateMap = new MapT<VectorT<StringT>>();
           appList = new VectorT();
-          logger.warn("qr " + qr.getName() + " has getQualifiedResourceType: " + qr.getQualifiedResourceType());
+
           XdaqExecutiveResource execResource = ((XdaqExecutiveResource)qr);
           logger.warn("executive " + qr.getName() + " has number of applications " + execResource.getNumApplications());
 
           for( XdaqApplicationResource app : execResource.getApplications()){
-            logger.warn("l2 inner loop: app: " + app.getName());
-            logger.warn("exec" + execResource.getName() + "has app with name " + app.getName());
             appList.add(new StringT(app.getName()));
             // get the crate number from the hcalCrate app property
             if (app.getName().contains("hcalCrate")) {
@@ -82,10 +79,11 @@ public class HCALqgMapper {
               }
             }
           }
+          crateMap.put(crateNumber, appList); 
+          execMap.put(execName, crateMap);
+          crateMap = new MapT<VectorT<StringT>>();
         }
       }
-      crateMap.put(crateNumber, appList); 
-      execMap.put(execName, crateMap);
       qgMap = execMap;
     }
   }

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -30,11 +30,11 @@ import rcms.util.logger.RCMSLogger;
  * Example (this is made up, for clarity):
  * {
  *   HCAL_HBHE: {
- *                 Executive_0: {N/A:[hcalSupervisor_0, hcalPartitionViewer_0]},
+ *                 Executive_0: {non-crate:[hcalSupervisor_0, hcalPartitionViewer_0]},
  *                 Executive_1: {41 :[hcal::DTCManager_0, hcalCrate_0]},
  *              },
  *   HCAL_HF  : {
- *                  Executive_2: {N/A: [hcalPartitionViewer_1, hcalSupervisor_1]}
+ *                  Executive_2: {non-crate: [hcalPartitionViewer_1, hcalSupervisor_1]}
  *                  Executive_3: {42 : [hcalTrivialFU_0, hcalEventBuilder_0, hcal::DTCReadout_0, DummyTriggerAdapter_0, hcal::uHTRManager_1, hcal::DTCManager_2, hcalCrate_1]},
  *              }
  *  }
@@ -43,7 +43,7 @@ import rcms.util.logger.RCMSLogger;
  *  an individual key-value pair in the l1qgMap is called the "l2map"
  *  the value in that key-value pair is called the "execMap"
  *  the execMap should have only one key-value pair
- *  the key of the exec map is the crate number it corresponds to, or "N/A" if not applicable
+ *  the key of the exec map is the crate number it corresponds to, or "non-crate" if not applicable
  *  the key-value pair of the execMap is called the "crateMap"
  *  the value of the crateMap is a list of applications and is called the "appList"
  */
@@ -77,12 +77,12 @@ public class HCALqgMapper {
     protected level2qgMapper(List<Resource> level2childList) throws UserActionException {
       MapT<MapT<VectorT<StringT>>> execMap = new MapT<MapT<VectorT<StringT>>>();
       MapT<VectorT<StringT>> crateMap = new MapT<VectorT<StringT>>();
-      String crateNumber = "N/A"; // if it is not an executive corresponding to the crate
+      String crateNumber = "non-crate"; // if it is not an executive corresponding to the crate
       String execName = "";
       VectorT appList = new VectorT();
       for(Resource qr : level2childList) {
         // this list has apps and execs mixed together
-        crateNumber = "N/A"; // if it is not an executive corresponding to the crate
+        crateNumber = "non-crate"; // if it is not an executive corresponding to the crate
         execName = "NoExecName";
         if (qr.getQualifiedResourceType().contains("Executive")){
           execName = qr.getName();
@@ -170,7 +170,7 @@ public class HCALqgMapper {
      * @return a string of the crate number
      */
     public String getCrateOfApp(String appName, StringT fmName) {
-      String crate = "N/A";
+      String crate = "non-crate";
       MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) qgMap.getMap().get(fmName);
       for (MapT<VectorT<StringT>> crateMap : execMap.getMap().values()) {
         for (StringT crateKey : crateMap.getMap().keySet()) {
@@ -189,10 +189,10 @@ public class HCALqgMapper {
      * @return a string of the crate number
      */
     public String getCrateOfApp(String appName) {
-      String crate = "N/A";
+      String crate = "non-crate";
       for (StringT fmName : qgMap.getMap().keySet()) {
          crate = getCrateOfApp(appName, fmName);
-         if (!crate.equals("N/A")) break;
+         if (!crate.equals("non-crate")) break;
       }
       return crate;
     }

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -134,7 +134,6 @@ public class HCALqgMapper {
         for (StringT execKey : execMap.getMap().keySet()) {
           for (VectorT<StringT> appList : execMap.getMap().get(execKey).getMap().values()) {
             if (execKey.getString().equals(execName)) {
-              logger.warn("[JohnLogQG] execKey.getString(): " + execKey.getString());
               return appList;
             }
           }

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import rcms.fm.app.level1.HCALqgMapper.level1qgMapper;
 import rcms.fm.fw.parameter.type.MapT;
+import rcms.fm.fw.parameter.type.ParameterType;
 import rcms.fm.fw.parameter.type.StringT;
 import rcms.fm.fw.parameter.type.VectorT;
 import rcms.fm.fw.user.UserActionException;
@@ -23,6 +24,28 @@ import rcms.util.logger.RCMSLogger;
 /**
  * @author John Hakala
  * class for mapping out the qualified group of a particular configuration
+ * 
+ * the most important thing here is the level1qgMapper
+ * if you call level1qgMapper it should return a full representation of the qualified group (or at least only what we care about)
+ * Example (this is made up, for clarity):
+ * {
+ *   HCAL_HBHE: {
+ *                 Executive_0: {N/A:[hcalSupervisor_0, hcalPartitionViewer_0]},
+ *                 Executive_1: {41 :[hcal::DTCManager_0, hcalCrate_0]},
+ *              },
+ *   HCAL_HF  : {
+ *                  Executive_2: {N/A: [hcalPartitionViewer_1, hcalSupervisor_1]}
+ *                  Executive_3: {42 : [hcalTrivialFU_0, hcalEventBuilder_0, hcal::DTCReadout_0, DummyTriggerAdapter_0, hcal::uHTRManager_1, hcal::DTCManager_2, hcalCrate_1]},
+ *              }
+ *  }
+ *  
+ *  the whole map is called the "l1qgMap"
+ *  an individual key-value pair in the l1qgMap is called the "l2map"
+ *  the value in that key-value pair is called the "execMap"
+ *  the execMap should have only one key-value pair
+ *  the key of the exec map is the crate number it corresponds to, or "N/A" if not applicable
+ *  the key-value pair of the execMap is called the "crateMap"
+ *  the value of the crateMap is a list of applications and is called the "appList"
  */
 public class HCALqgMapper {
 
@@ -89,6 +112,7 @@ public class HCALqgMapper {
 
   /**
    * class for mapping out a level1 FM's QG 
+   * it makes the l1QGmap
    */
   public class level1qgMapper extends abstractQGmapper {
     protected Resource functionManagerResource = null;
@@ -101,21 +125,99 @@ public class HCALqgMapper {
      */
     public level1qgMapper(Resource l1FMqr, QualifiedGroup qg) throws UserActionException {
       this.qg = qg;
-      MapT<MapT<MapT<VectorT<StringT>>>> l2Map = new MapT<MapT<MapT<VectorT<StringT>>>>();
+      MapT<MapT<MapT<VectorT<StringT>>>> l1QGmap = new MapT<MapT<MapT<VectorT<StringT>>>>();
       List<QualifiedResource> l2FMlist = qg.seekQualifiedResourcesOfType(new FunctionManager());
       for (QualifiedResource qr: l2FMlist) {
         try {
           Group l2group = qg.rs.retrieveLightGroup(qr.getResource());
           List<Resource> level2execs = l2group.getChildrenResources();
           level2qgMapper level2mapper = new level2qgMapper(level2execs);
-          MapT<MapT<VectorT<StringT>>> level2map = (MapT<MapT<VectorT<StringT>>>) level2mapper.getMap();
-          l2Map.put(qr.getName(), level2map);
+          MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) level2mapper.getMap();
+          l1QGmap.put(qr.getName(), execMap);
         }
         catch (UserActionException | DBConnectorException e) {
           throw new UserActionException(e.getMessage());
         }
       }
-      qgMap = l2Map;
+      qgMap = l1QGmap;
+      if (!isQGmapValid()) {
+        throw new UserActionException("Error creating the QG map!");
+      }
+    }
+    
+    /**
+     * get the executive corresponding to a given crate
+     * @param crateNumber, the crate number
+     * @return a string of the executive's name, e.g. Executive_5
+     * @throws UserActionException if the crate couldn't be found
+     */
+    public String getExecOfCrate(Integer crateNumber) throws UserActionException{
+      for (ParameterType<?> l2FMmap : qgMap.getMap().values()) {
+        MapT<MapT<VectorT<StringT>>> l2Map = ((MapT<MapT<VectorT<StringT>>>) l2FMmap);
+        for (MapT<VectorT<StringT>> execMap : l2Map.getMap().values()) {
+          if (execMap.getMap().keySet().contains(new StringT(Integer.toString(crateNumber)))){
+            return execMap.getMap().keySet().toArray()[0].toString(); // execs should only be associated with one crate
+          }
+        }
+      }
+      throw new UserActionException("Could not find executive corresponding to crate " + crateNumber);
+    }
+
+    /**
+     * return the crate corresponding to an application, specifying which FM the app belongs to
+     * @param appName the application's name
+     * @param fmName the FM's name
+     * @return a string of the crate number
+     */
+    public String getCrateOfApp(String appName, StringT fmName) {
+      String crate = "N/A";
+      MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) qgMap.getMap().get(fmName);
+      for (StringT crateKey : execMap.getMap().keySet()) {
+        String thisCrate = crateKey.toString();
+        MapT<VectorT<StringT>> crateMap = execMap.get(crateKey);
+        for (VectorT<StringT> appList : crateMap.getMap().values()) {
+          if (appList.contains(new StringT(appName))) {
+            crate =thisCrate; 
+          }
+        }
+      }
+      return crate;
+    }
+
+    /**
+     * return the crate corresponding to an application
+     * @param appName the app's name
+     * @return a string of the crate number
+     */
+    public String getCrateOfApp(String appName) {
+      String crate = "N/A";
+      for (StringT fmName : qgMap.getMap().keySet()) {
+         crate = getCrateOfApp(appName, fmName);
+         if (!crate.equals("N/A")) break;
+      }
+      return crate;
+    }
+
+    /**
+     * sanity check that the l1qgMap is valid
+     * the rules for validity are:
+     * a) there is exactly one crate corresponding to one executive
+     * b) there is exactly one appList per executive
+     * @return a bool where 1 is valid and 0 is not valid
+     */
+    private boolean isQGmapValid () {
+      for (StringT level2key : qgMap.getMap().keySet()) {
+        MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) qgMap.getMap().get(level2key);
+        if (execMap.getMap().keySet().size() > 1) {
+          return false;
+        }
+        for (MapT<VectorT<StringT>> crateMap : execMap.getMap().values()) {
+          if (crateMap.getMap().keySet().size() > 1) {
+            return false;
+          }
+        }
+      }
+      return true;
     }
   }
 }

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -1,0 +1,122 @@
+package rcms.fm.app.level1;
+
+import java.util.List;
+
+import rcms.fm.app.level1.HCALqgMapper.level1qgMapper;
+import rcms.fm.fw.parameter.type.MapT;
+import rcms.fm.fw.parameter.type.StringT;
+import rcms.fm.fw.parameter.type.VectorT;
+import rcms.fm.fw.user.UserActionException;
+import rcms.fm.resource.QualifiedGroup;
+import rcms.fm.resource.QualifiedResource;
+import rcms.fm.resource.qualifiedresource.FunctionManager;
+import rcms.fm.resource.qualifiedresource.XdaqExecutive;
+import rcms.resourceservice.db.resource.Resource;
+import rcms.resourceservice.db.resource.config.ConfigProperty;
+import rcms.resourceservice.db.resource.xdaq.XdaqApplicationResource;
+import rcms.resourceservice.db.resource.xdaq.XdaqExecutiveResource;
+
+/**
+ * @author John Hakala
+ * class for mapping out the qualified group of a particular configuration
+ */
+public class HCALqgMapper {
+
+
+  /**
+   * abstract class for various kinds of maps of qualified groups
+   */
+  abstract public static class abstractQGmapper {
+    protected Resource functionManagerResource = null;
+    protected QualifiedGroup qg = null;
+    static MapT<?> qgMap = null;
+
+    /**
+     * abstract class on which the QG mappers for level1 QGs level2 QGs are based
+     * @param fmResource the qualified resource of the FM for which to make a map of
+     */
+    abstractQGmapper(Resource fmResource) {
+      // extract the qualified group from the fm's Resource object
+      this.qg = (new FunctionManager(fmResource)).getQualifiedGroup();
+    }
+
+    /**
+     * generic getter for the qg map
+     */
+     public MapT<?> getMap() {
+      return qgMap;
+    }
+  }
+
+
+  /**
+   * class that does bookkeeping of the level2 FM qualified groups
+   */
+  public class level2qgMapper extends abstractQGmapper {
+
+    /**
+     * method that creates the map for a level2 fm
+     * @param l2FMqr the qualified resource of a level2 fm
+     * @throws UserActionException if there are problems mapping it out
+     */
+    protected level2qgMapper(Resource l2FMqr) throws UserActionException {
+      super(l2FMqr);
+      if (! l2FMqr.getClass().equals(new HCALlevelTwoFunctionManager().getClass())){
+        throw new UserActionException("tried to construct a level2 qualified group for FM " + l2FMqr.getName() + "but it is not a level2 FM!");
+      }
+      List<QualifiedResource> xdaqExecList = qg.seekQualifiedResourcesOfType(new XdaqExecutive());
+      MapT<MapT<VectorT<StringT>>> execMap = new MapT<MapT<VectorT<StringT>>>();
+      MapT<VectorT<StringT>> crateMap = new MapT<VectorT<StringT>>();
+      for( QualifiedResource qr : xdaqExecList) {
+        String crateNumber = "N/A";
+        VectorT appList = new VectorT();
+        XdaqExecutiveResource execResource = (XdaqExecutiveResource)(qr.getResource());
+        for( XdaqApplicationResource app : execResource.getApplications()){
+          appList.add(new StringT(app.getName()));
+          if (app.getName().contains("hcalCrate")) {
+            for (ConfigProperty crateAppProperty : app.getProperties()){
+              if (crateAppProperty.getName().equals("crateId")){
+                crateNumber = crateAppProperty.getValue();
+              }
+            }
+          }
+        }
+        crateMap.put(crateNumber, appList); 
+        execMap.put(qr.getName(), crateMap);
+      }
+      qgMap = execMap;
+    }
+  }
+
+  /**
+   * class for mapping out a level1 FM's QG 
+   */
+  public class level1qgMapper extends abstractQGmapper {
+
+    /**
+     * method that creates a map of a level1 FM's qualified group
+     * @param l1FMqr the level1 FM qualified resource
+     * @throws UserActionException if it has issues
+     */
+    public level1qgMapper(Resource l1FMqr) throws UserActionException {
+      super(l1FMqr);
+      if (! l1FMqr.getClass().equals(new HCALlevelOneFunctionManager().getClass())){
+        throw new UserActionException("tried to construct a level2 qualified group for FM " + l1FMqr.getName() + "but it is not a level2 FM!");
+      }
+
+      MapT<MapT<MapT<VectorT<StringT>>>> l2Map = new MapT<MapT<MapT<VectorT<StringT>>>>();
+      List<QualifiedResource> l2FMlist = qg.seekQualifiedResourcesOfType(new FunctionManager());
+      for (QualifiedResource qr: l2FMlist) {
+        try {
+          level2qgMapper level2mapper = new level2qgMapper(qr.getResource());
+          MapT<MapT<VectorT<StringT>>> level2map = (MapT<MapT<VectorT<StringT>>>) level2mapper.getMap();
+          l2Map.put(qr.getName(), level2map);
+        }
+        catch (UserActionException e) {
+          throw e;
+        }
+      }
+      qgMap = l2Map;
+    }
+  }
+}

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -198,6 +198,41 @@ public class HCALqgMapper {
     }
 
     /**
+     * method for getting all the apps in an executive
+     * @param execName the name of the executive, e.g. Executive_5
+     * @return a VectorT of app names
+     * @throws UserActionException if it fails to find the executive
+     */
+    public VectorT<StringT> getAppsOfExec(String execName) throws UserActionException {
+      MapT<MapT<MapT<VectorT<StringT>>>> l1qgMap = (MapT<MapT<MapT<VectorT<StringT>>>>) qgMap.getMap();
+      for (StringT execKey : l1qgMap.getMap().keySet()) {
+        for (MapT<VectorT<StringT>> crateMap : l1qgMap.getMap().get(execKey).getMap().values()) {
+          for (VectorT<StringT> appList : crateMap.getMap().values()) {
+            if (execKey.getString().equals(execName)) {
+              return appList;
+            }
+          }
+        }
+      }
+      throw new UserActionException("Did not find executive with name " + execName + "in QG!");
+    }
+
+    /**
+     * method for getting all the apps corresponding to a crate
+     * @param crateNumber the crate number
+     * @return a VectorT of app names
+     * @throws UserActionException if the crate number is bad or if it can't find the executive of that crate
+     */
+    public VectorT<StringT> getAppsOfCrate(String crateNumber) throws UserActionException {
+      try {
+        return getAppsOfExec(getExecOfCrate(Integer.parseInt(crateNumber)));
+      }
+      catch (NumberFormatException | UserActionException e) {
+        throw new UserActionException("Problem getting apps corresponding to crate " + crateNumber + " : " + e.getMessage());
+      }
+    }
+
+    /**
      * sanity check that the l1qgMap is valid
      * the rules for validity are:
      * a) there is exactly one crate corresponding to one executive
@@ -205,12 +240,10 @@ public class HCALqgMapper {
      * @return a bool where 1 is valid and 0 is not valid
      */
     private boolean isQGmapValid () {
-      logger.warn(qgMap.toString());
       for (StringT level2key : qgMap.getMap().keySet()) {
         MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) qgMap.getMap().get(level2key);
         for (MapT<VectorT<StringT>> crateMap : execMap.getMap().values()) {
           if (crateMap.getMap().keySet().size() > 1) {
-            logger.warn("crateMap.getMap().keySet().size(): " + crateMap.getMap().keySet().size());
             return false;
           }
         }

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -87,8 +87,11 @@ public class HCALqgMapper {
           String crateNumber = "N/A";
           VectorT appList = new VectorT();
           logger.warn("qr " + qr.getName() + " has getQualifiedResourceType: " + qr.getQualifiedResourceType());
-          XdaqExecutiveResource execResource = (XdaqExecutiveResource)(qr);
+          XdaqExecutiveResource execResource = ((XdaqExecutiveResource)qr);
+          logger.warn("executive " + qr.getName() + " has number of applications " + execResource.getNumApplications());
+
           for( XdaqApplicationResource app : execResource.getApplications()){
+            logger.warn("exec" + execResource.getName() + "has app with name " + app.getName());
             appList.add(new StringT(app.getName()));
             if (app.getName().contains("hcalCrate")) {
               for (ConfigProperty crateAppProperty : app.getProperties()){

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -69,7 +69,7 @@ public class HCALqgMapper {
      * @param l2FMqr the qualified resource of a level2 fm
      * @throws UserActionException if there are problems mapping it out
      */
-    protected level2qgMapper(Resource l2FMqr, List<Resource> xdaqExecList) throws UserActionException {
+    protected level2qgMapper(List<Resource> xdaqExecList) throws UserActionException {
       //super(l2FMqr, l2qg);
       //if (! l2FMqr.getClass().equals(new HCALlevelTwoFunctionManager().getClass())){
       //  throw new UserActionException("tried to construct a level2 qualified group for FM " + l2FMqr.getName() + "but it is not a level2 FM!");
@@ -80,10 +80,12 @@ public class HCALqgMapper {
       String crateNumber = "N/A";
       VectorT appList = new VectorT();
       String qrName = "";
+      String execName = "";
       for(Resource qr : xdaqExecList) {
         qrName = qr.getName();
         logger.warn("l2 outer loop: qr: " + qr.getName());
         if (qr.getQualifiedResourceType().contains("Executive")){
+          execName = qr.getName();
           execMap = new MapT<MapT<VectorT<StringT>>>();
           crateMap = new MapT<VectorT<StringT>>();
           appList = new VectorT();
@@ -106,7 +108,7 @@ public class HCALqgMapper {
         }
       }
       crateMap.put(crateNumber, appList); 
-      execMap.put(qrName, crateMap);
+      execMap.put(execName, crateMap);
       qgMap = execMap;
     }
   }
@@ -134,7 +136,7 @@ public class HCALqgMapper {
           Group l2group = qg.rs.retrieveLightGroup(qr.getResource());
           List<Resource> level2execs = l2group.getChildrenResources();
           //logger.warn(level2.print());
-          level2qgMapper level2mapper = new level2qgMapper(qr.getResource(), level2execs);
+          level2qgMapper level2mapper = new level2qgMapper(level2execs);
           // TODO: fix this
           // level2qgMapper level2mapper = new level2qgMapper(qr.getResource(), qr.getChildrenResources());
           MapT<MapT<VectorT<StringT>>> level2map = (MapT<MapT<VectorT<StringT>>>) level2mapper.getMap();

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -75,22 +75,24 @@ public class HCALqgMapper {
       //  throw new UserActionException("tried to construct a level2 qualified group for FM " + l2FMqr.getName() + "but it is not a level2 FM!");
       //}
       //List<QualifiedResource> xdaqExecList = l2qg.seekQualifiedResourcesOfType(new XdaqExecutive());
-      logger.warn("QRs in l2qg:");
-      //TODO: nothing is in here
-      for (Resource qr : xdaqExecList) {
-        logger.warn(qr.getName());
-      }
       MapT<MapT<VectorT<StringT>>> execMap = new MapT<MapT<VectorT<StringT>>>();
       MapT<VectorT<StringT>> crateMap = new MapT<VectorT<StringT>>();
+      String crateNumber = "N/A";
+      VectorT appList = new VectorT();
+      String qrName = "";
       for(Resource qr : xdaqExecList) {
-       if (qr.getQualifiedResourceType().contains("Executive")){
-          String crateNumber = "N/A";
-          VectorT appList = new VectorT();
+        qrName = qr.getName();
+        logger.warn("l2 outer loop: qr: " + qr.getName());
+        if (qr.getQualifiedResourceType().contains("Executive")){
+          execMap = new MapT<MapT<VectorT<StringT>>>();
+          crateMap = new MapT<VectorT<StringT>>();
+          appList = new VectorT();
           logger.warn("qr " + qr.getName() + " has getQualifiedResourceType: " + qr.getQualifiedResourceType());
           XdaqExecutiveResource execResource = ((XdaqExecutiveResource)qr);
           logger.warn("executive " + qr.getName() + " has number of applications " + execResource.getNumApplications());
 
           for( XdaqApplicationResource app : execResource.getApplications()){
+            logger.warn("l2 inner loop: app: " + app.getName());
             logger.warn("exec" + execResource.getName() + "has app with name " + app.getName());
             appList.add(new StringT(app.getName()));
             if (app.getName().contains("hcalCrate")) {
@@ -101,10 +103,10 @@ public class HCALqgMapper {
               }
             }
           }
-          crateMap.put(crateNumber, appList); 
-          execMap.put(qr.getName(), crateMap);
         }
       }
+      crateMap.put(crateNumber, appList); 
+      execMap.put(qrName, crateMap);
       qgMap = execMap;
     }
   }
@@ -127,6 +129,7 @@ public class HCALqgMapper {
       MapT<MapT<MapT<VectorT<StringT>>>> l2Map = new MapT<MapT<MapT<VectorT<StringT>>>>();
       List<QualifiedResource> l2FMlist = qg.seekQualifiedResourcesOfType(new FunctionManager());
       for (QualifiedResource qr: l2FMlist) {
+        logger.warn("l1 loop: qr: " + qr.getName());
         try {
           Group l2group = qg.rs.retrieveLightGroup(qr.getResource());
           List<Resource> level2execs = l2group.getChildrenResources();

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -66,7 +66,6 @@ public class HCALqgMapper {
           appList = new VectorT();
 
           XdaqExecutiveResource execResource = ((XdaqExecutiveResource)qr);
-          logger.warn("executive " + qr.getName() + " has number of applications " + execResource.getNumApplications());
 
           for( XdaqApplicationResource app : execResource.getApplications()){
             appList.add(new StringT(app.getName()));
@@ -105,7 +104,6 @@ public class HCALqgMapper {
       MapT<MapT<MapT<VectorT<StringT>>>> l2Map = new MapT<MapT<MapT<VectorT<StringT>>>>();
       List<QualifiedResource> l2FMlist = qg.seekQualifiedResourcesOfType(new FunctionManager());
       for (QualifiedResource qr: l2FMlist) {
-        logger.warn("l1 loop: qr: " + qr.getName());
         try {
           Group l2group = qg.rs.retrieveLightGroup(qr.getResource());
           List<Resource> level2execs = l2group.getChildrenResources();

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -154,9 +154,9 @@ public class HCALqgMapper {
     public String getExecOfCrate(Integer crateNumber) throws UserActionException{
       for (ParameterType<?> l2FMmap : qgMap.getMap().values()) {
         MapT<MapT<VectorT<StringT>>> l2Map = ((MapT<MapT<VectorT<StringT>>>) l2FMmap);
-        for (MapT<VectorT<StringT>> execMap : l2Map.getMap().values()) {
-          if (execMap.getMap().keySet().contains(new StringT(Integer.toString(crateNumber)))){
-            return execMap.getMap().keySet().toArray()[0].toString(); // execs should only be associated with one crate
+        for (StringT execKey : l2Map.getMap().keySet()) {
+          if (l2Map.getMap().get(execKey).getMap().keySet().contains(new StringT(Integer.toString(crateNumber)))){
+            return execKey.getString(); 
           }
         }
       }
@@ -172,12 +172,11 @@ public class HCALqgMapper {
     public String getCrateOfApp(String appName, StringT fmName) {
       String crate = "N/A";
       MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) qgMap.getMap().get(fmName);
-      for (StringT crateKey : execMap.getMap().keySet()) {
-        String thisCrate = crateKey.toString();
-        MapT<VectorT<StringT>> crateMap = execMap.get(crateKey);
-        for (VectorT<StringT> appList : crateMap.getMap().values()) {
+      for (MapT<VectorT<StringT>> crateMap : execMap.getMap().values()) {
+        for (StringT crateKey : crateMap.getMap().keySet()) {
+          VectorT<StringT>appList = crateMap.getMap().get(crateKey);
           if (appList.contains(new StringT(appName))) {
-            crate =thisCrate; 
+            crate = crateKey.getString(); 
           }
         }
       }
@@ -206,13 +205,12 @@ public class HCALqgMapper {
      * @return a bool where 1 is valid and 0 is not valid
      */
     private boolean isQGmapValid () {
+      logger.warn(qgMap.toString());
       for (StringT level2key : qgMap.getMap().keySet()) {
         MapT<MapT<VectorT<StringT>>> execMap = (MapT<MapT<VectorT<StringT>>>) qgMap.getMap().get(level2key);
-        if (execMap.getMap().keySet().size() > 1) {
-          return false;
-        }
         for (MapT<VectorT<StringT>> crateMap : execMap.getMap().values()) {
           if (crateMap.getMap().keySet().size() > 1) {
+            logger.warn("crateMap.getMap().keySet().size(): " + crateMap.getMap().keySet().size());
             return false;
           }
         }

--- a/src/rcms/fm/app/level1/HCALqgMapper.java
+++ b/src/rcms/fm/app/level1/HCALqgMapper.java
@@ -266,16 +266,8 @@ public class HCALqgMapper {
    * class so that the level2 FMs can receive the qgMap from the level1 and have the utilities defined by abstractQGmapReader 
    */
   public class level2qgMapParser extends abstractQGmapReader {
-    public level2qgMapParser() {
-      qgMap = null;
-    }
-    public void setMap(MapT<?> externalMap) throws UserActionException {
-      if (!isQGmapValid()) {
-        qgMap = externalMap;
-      }
-      else {
-        throw new UserActionException("the level2qgMapParser received an invalid qgMap from the level1");
-      }
+    public level2qgMapParser(MapT<?> externalMap) {
+      qgMap = externalMap;
     }
   }
 }


### PR DESCRIPTION
This PR introduces a new class, HCALqgMapper, that creates a map of the qualified group, which will help with easing writing code that needs to traverse the QG (e.g. in the masker,  where previously we had code that navigates the QG) as well as giving an executive<->crate mapping for finding crate numbers for error messages (#361), as well as crate masking (#344).

So far I've successfully tested using this to replace the current executive masking code (test performed at 904). I want to also address #344 and #361 using these new methods -- will update when ready. 