### PR TITLE
Add TPG_KEY parameter

### DIFF
--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -55,6 +55,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 		this.put( new FunctionManagerParameter<StringT>  ("STATE"                            ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // State the Function Manager is currently in
 		this.put( new FunctionManagerParameter<StringT>  ("SEQ_NAME"                         ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // Run sequence name currently
 		this.put( new FunctionManagerParameter<StringT>  ("RUN_KEY"                          ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // Global run key
+		this.put( new FunctionManagerParameter<StringT>  ("TPG_KEY"                          ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // Global TPG KEY
 		this.put( new FunctionManagerParameter<StringT>  ("RUN_MODE"                         ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // Skeletor comment: "mode can be "Normal" or "Debug". Influences the behaviour of the top FM."
 		this.put( new FunctionManagerParameter<StringT>  ("ACTION_MSG"                       ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // Action message (fishy zone), visible in level0 and local GUIs
 		this.put( new FunctionManagerParameter<StringT>  ("ERROR_MSG"                        ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // Error message visible in red in level0 gui

--- a/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelOneEventHandler.java
@@ -634,6 +634,7 @@ public class HCALlevelOneEventHandler extends HCALEventHandler {
         // get the tpg key from the configure command
         if (parameterSet.get("TPG_KEY") != null) {
           TpgKey = ((StringT)parameterSet.get("TPG_KEY").getValue()).getString();
+          functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("TPG_KEY",new StringT(TpgKey)));
           functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("CONFIGURED_WITH_TPG_KEY",new StringT(TpgKey)));
           String warnMessage = "[HCAL LVL1 " + functionManager.FMname + "] Received a L1 TPG key: " + TpgKey;
           logger.info(warnMessage);


### PR DESCRIPTION
Fixes a bug in #413 . `TPG_KEY` was in LV0 pSet but not in FM parameter.
`TPG_KEY` is what we use within our FM.
`CONFIGURED_WITH_TPG_KEY` is what we set for LV0 to read.