### PR TITLE
Start TA during starting from supervisor

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -2057,6 +2057,7 @@ public class HCALEventHandler extends UserEventHandler {
                 }
                 XDAQParameter pam = null;
                 String status = "undefined";
+                String TriggerTaskState = "undefined";
                 Double NextEventNumber = -1.0;
 
                 // ask for the status of the TriggerAdapter and wait until it is Ready, Failed
@@ -2064,9 +2065,10 @@ public class HCALEventHandler extends UserEventHandler {
                   try {
                     pam =((XdaqApplication)qr).getXDAQParameter();
 
-                    pam.select(new String[] {"stateName", "NextEventNumber"});
+                    pam.select(new String[] {"stateName", "NextEventNumber","TriggerTaskState"});
                     pam.get();
                     status = pam.getValue("stateName");
+                    TriggerTaskState = pam.getValue("TriggerTaskState");
                     if (status==null) {
                       String errMessage = "[HCAL " + functionManager.FMname + "] Error! Asking the TA for the stateName when Running resulted in a NULL pointer - this is bad!";
                       functionManager.goToError(errMessage);
@@ -2108,8 +2110,8 @@ public class HCALEventHandler extends UserEventHandler {
                   functionManager.goToError(errMessage);
                 }
 
-                if (status.equals("Ready")) {
-                  logger.info("[HCAL " + functionManager.FMname + "] The Trigger adapter reports: " + status + " , which means that all Triggers were sent ...");
+                if (status.equals("Ready") || TriggerTaskState.equals("IDLE")) {
+                  logger.info("[HCAL " + functionManager.FMname + "] The Trigger adapter has status= " + status + " and triggerTaskState= "+TriggerTaskState+", which means that all Triggers were sent ...");
                   functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("")));
                   functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("Stopping the TA ...")));
 

--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -766,9 +766,12 @@ public class HCALEventHandler extends UserEventHandler {
           try{
             if (functionManager.FMrole.equals("EvmTrig")){
               XDAQParameter pam = xdaqApp.getXDAQParameter();
-              pam.select(new String[] {"SessionID"});
+              pam.select(new String[] {"SessionID","IgnoreTriggerForEnable"});
               pam.setValue("SessionID"  ,sid.toString());
               logger.info("[HCAL " + functionManager.FMname + "] Sent SID to supervisor: " + Sid);
+              // IgnoreTriggerForEnable = false 
+              pam.setValue("IgnoreTriggerForEnable"  ,"false");
+              logger.info("[HCAL " + functionManager.FMname + "] Sent IgnoreTriggerForEnable=false to supervisor: " );
 
               pam.send();
             }

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -943,53 +943,12 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
       // reset the non-async error state handling
       functionManager.ErrorState = false;
       
-      // only in local runs when all triggers were sent the run is stopped with 60 sec timeout
-      if (functionManager.FMrole.equals("EvmTrig")) {
 
-        // finally start the TriggerAdapters
-        if (functionManager.containerTriggerAdapter!=null) {
-          if (!functionManager.containerTriggerAdapter.isEmpty() && !functionManager.FMWasInPausedState) {
-            //try {
-            //  //logger.info("[JohnLog4] [HCAL LVL2 " + functionManager.FMname + "] Issuing the L1As i.e. sending Enable to the TriggerAdapter ...");
-            //  logger.info("[HCAL LVL2 " + functionManager.FMname + "] NOT Issuing the L1As i.e. sending Enable to the TriggerAdapter ...");
-            //  functionManager.containerTriggerAdapter.execute(HCALInputs.HCALSTART);
-            //}
-            //catch (QualifiedResourceContainerException e) {
-            //  String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: starting (TriggerAdapter=Enable) failed ...";
-            //  functionManager.goToError(errMessage,e);
-            //}
-          }
-        }
-
-        // set actions for local runs
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("waiting for run to finish ...")));
-
-        logger.debug("[HCAL LVL2 " + functionManager.FMname + "] runningAction executed ...");
-
-      }
-      else {
-        // set actions for gloabl runs
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
-        functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("running like hell ...")));
-      }
-      //XdaqApplicationContainer lpmContainer =  new XdaqApplicationContainer(functionManager.containerXdaqApplication.getApplicationsOfClass("tcds::lpm::LPMController"));      
-      //if (!lpmContainer.isEmpty()) {
-      //  logger.info("[JohnLog4] " + functionManager.FMname + ": Sending Enable to the LPMController.");
-      //  try {
-      //    lpmContainer.execute(HCALInputs.HCALSTART);
-      //  }
-      //  catch (QualifiedResourceContainerException e) {
-      //    String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: starting (LPMController=Enable) failed ... Message: " + e.getMessage();
-      //    logger.error(errMessage,e);
-      //    functionManager.sendCMSError(errMessage);
-      //    functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT("Error")));
-      //    functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("oops - technical difficulties ...")));
-      //    if (TestMode.equals("off")) { functionManager.firePriorityEvent(HCALInputs.SETERROR); functionManager.ErrorState = true; return;}
-      //  }
-      //}
-      // patch for pause-resume behavior
+      // set actions for gloabl runs
+      functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(functionManager.getState().getStateString())));
+      functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("running like hell ...")));
       functionManager.FMWasInPausedState = false;
+      logger.info("[HCAL LVL2 " + functionManager.FMname + "] runningAction executed ...");
     }
   }
 
@@ -1431,17 +1390,11 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
 
       // stop HCAL
       if (!functionManager.containerhcalSupervisor.isEmpty()) {
-
-        {
-          String debugMessage = "[HCAL LVL2 " + functionManager.FMname + "] HCAL supervisor for stopRunning found- good!";
-          logger.debug(debugMessage);
-        }
         try {
-
           // define stop time
           StopTime = new Date();
 
-          logger.info("[HCAL LVL2 " + functionManager.FMname + "]   Sending AsyncDisable to non-EvmTrig supervisor");
+          logger.info("[HCAL LVL2 " + functionManager.FMname + "]   Sending AsyncDisable to supervisor");
           functionManager.containerhcalSupervisor.execute(HCALInputs.HCALASYNCDISABLE);
         }
         catch (QualifiedResourceContainerException e) {

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -969,15 +969,15 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         // finally start the TriggerAdapters
         if (functionManager.containerTriggerAdapter!=null) {
           if (!functionManager.containerTriggerAdapter.isEmpty() && !functionManager.FMWasInPausedState) {
-            try {
-              //logger.info("[JohnLog4] [HCAL LVL2 " + functionManager.FMname + "] Issuing the L1As i.e. sending Enable to the TriggerAdapter ...");
-              logger.info("[HCAL LVL2 " + functionManager.FMname + "] Issuing the L1As i.e. sending Enable to the TriggerAdapter ...");
-              functionManager.containerTriggerAdapter.execute(HCALInputs.HCALSTART);
-            }
-            catch (QualifiedResourceContainerException e) {
-              String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: starting (TriggerAdapter=Enable) failed ...";
-              functionManager.goToError(errMessage,e);
-            }
+            //try {
+            //  //logger.info("[JohnLog4] [HCAL LVL2 " + functionManager.FMname + "] Issuing the L1As i.e. sending Enable to the TriggerAdapter ...");
+            //  logger.info("[HCAL LVL2 " + functionManager.FMname + "] NOT Issuing the L1As i.e. sending Enable to the TriggerAdapter ...");
+            //  functionManager.containerTriggerAdapter.execute(HCALInputs.HCALSTART);
+            //}
+            //catch (QualifiedResourceContainerException e) {
+            //  String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: starting (TriggerAdapter=Enable) failed ...";
+            //  functionManager.goToError(errMessage,e);
+            //}
           }
         }
 
@@ -1457,17 +1457,19 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           logger.debug(debugMessage);
         }
 
+        if (!functionManager.FMrole.equals("EvmTrig")) {
         try {
 
           // define stop time
           StopTime = new Date();
 
-          logger.info("[HCAL LVL2 " + functionManager.FMname + "]  Sending AsyncDisable to supervisor");
+          logger.info("[HCAL LVL2 " + functionManager.FMname + "]   Sending AsyncDisable to non-EvmTrig supervisor");
           functionManager.containerhcalSupervisor.execute(HCALInputs.HCALASYNCDISABLE);
         }
         catch (QualifiedResourceContainerException e) {
           String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException:  step 2/2 (AsyncDisable to hcalSupervisor) failed ...";
           functionManager.goToError(errMessage,e);
+        }
         }
       }
       else if (!functionManager.FMrole.equals("Level2_TCDSLPM")) {

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -1436,8 +1436,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
           String debugMessage = "[HCAL LVL2 " + functionManager.FMname + "] HCAL supervisor for stopRunning found- good!";
           logger.debug(debugMessage);
         }
-
-        if (!functionManager.FMrole.equals("EvmTrig")) {
         try {
 
           // define stop time
@@ -1449,7 +1447,6 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
         catch (QualifiedResourceContainerException e) {
           String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException:  step 2/2 (AsyncDisable to hcalSupervisor) failed ...";
           functionManager.goToError(errMessage,e);
-        }
         }
       }
       else if (!functionManager.FMrole.equals("Level2_TCDSLPM")) {

--- a/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALlevelTwoEventHandler.java
@@ -1356,14 +1356,14 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
                   logger.info("[HCAL LVL2 " + functionManager.FMname + "] EvmTrig FM: TriggerAdapter is already in READY, not sending disable.");
                 }
                 else{
-                  logger.info("[HCAL LVL2 " + functionManager.FMname + "] EvmTrig FM: TriggerAdapter is in the state="+status+", send HCALASYNCDISABLE to TriggerAdapter");
-                  functionManager.containerTriggerAdapter.execute(HCALInputs.HCALASYNCDISABLE);
+                  //logger.info("[HCAL LVL2 " + functionManager.FMname + "] EvmTrig FM: TriggerAdapter is in the state="+status+", not sending HCALASYNCDISABLE to TriggerAdapter");
+                  //functionManager.containerTriggerAdapter.execute(HCALInputs.HCALASYNCDISABLE);
                 }
               }
-              catch (QualifiedResourceContainerException e) {
-                String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: step 1/2 (TriggerAdapter Disable) failed ...";
-                functionManager.goToError(errMessage,e);
-              }
+              //catch (QualifiedResourceContainerException e) {
+              //  String errMessage = "[HCAL LVL2 " + functionManager.FMname + "] Error! QualifiedResourceContainerException: step 1/2 (TriggerAdapter Disable) failed ...";
+              //  functionManager.goToError(errMessage,e);
+              //}
               catch (XDAQTimeoutException e) {
                   String errMessage = "[HCAL " + functionManager.FMname + "] Error! XDAQTimeoutException: Asking TA status during stopping action";
                   functionManager.goToError(errMessage,e);
@@ -1375,8 +1375,8 @@ public class HCALlevelTwoEventHandler extends HCALEventHandler {
             }
 
             // waits for the TriggerAdapter to be in the Ready or Failed state, the timeout is 10s
-            logger.info("[HCAL LVL2 " + functionManager.FMname + "] EvmTrig FM: waitForTriggerAdapter to be in state \"Ready\" for up to 10s");
-            waitforTriggerAdapter(10);
+            //logger.info("[HCAL LVL2 " + functionManager.FMname + "] EvmTrig FM: waitForTriggerAdapter to be in state \"Ready\" for up to 10s");
+            //waitforTriggerAdapter(10);
 
           }
           else {


### PR DESCRIPTION
We used to have `IgnoreTriggerForEnable=True` in supervisor and FM starts the TA during running action. 
This should no longer be needed with EvmTrigFM scheduled to start last.
Supervisor can start TA last during starting to officially start the run, FM then transit to running state when supervisor updated its global state to running.

Tested at 904 for (click-stop + auto-stop) x (multi + single partition run) 
Tested at P5 for sequencer runs with a series of click-stop (Run 315283). 
I have not encountered any stopping issue with click-stop and auto-stop, but the logs need to be studied in details to make sure it's working correctly.