### PR TITLE
Publish config time

### DIFF
--- a/src/rcms/fm/app/level1/HCALEventHandler.java
+++ b/src/rcms/fm/app/level1/HCALEventHandler.java
@@ -935,6 +935,8 @@ public class HCALEventHandler extends UserEventHandler {
 
     maskedAppsForRunInfo = ((VectorT<StringT>)functionManager.getParameterSet().get("MASKED_RESOURCES").getValue()).toString();
     emptyFMsForRunInfo   = ((VectorT<StringT>)functionManager.getParameterSet().get("EMPTY_FMS").getValue()).toString();
+    Integer config_time  = ((IntegerT)functionManager.getParameterSet().get("CONFIG_TIME").getValue()).getInteger();
+
 
     localParams.put(   "FM_FULLPATH"           ,  functionManager.FMfullpath                  );
     localParams.put(   "FM_NAME"               ,  functionManager.FMname                      );
@@ -945,7 +947,7 @@ public class HCALEventHandler extends UserEventHandler {
     localParams.put(   "TRIGGERS"              ,  String.valueOf(TriggersToTake)              );
     localParams.put(   "MASKED_RESOURCES"      ,  maskedAppsForRunInfo                        );
     localParams.put(   "EMPTY_FMS"             ,  emptyFMsForRunInfo                          );
-    localParams.put(   "TRIGGERS"              ,  String.valueOf(TriggersToTake)              );
+    localParams.put(   "CONFIG_TIME"           ,  String.valueOf(config_time)                 );
 
     // TODO JHak put in run start time and stop times. This was always broken.
 
@@ -1811,6 +1813,7 @@ public class HCALEventHandler extends UserEventHandler {
             pollCompletion(); // get the latest update of the LVL2 config times
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("STATE",new StringT(HCALStates.CONFIGURED.toString())));
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ACTION_MSG",new StringT("... reached the \"" + HCALStates.CONFIGURED.toString() + "\" state in about " + elapsedseconds + " sec.")));
+            functionManager.getHCALparameterSet().put(new FunctionManagerParameter<IntegerT>("CONFIG_TIME",new IntegerT(elapsedseconds)));
             functionManager.getHCALparameterSet().put(new FunctionManagerParameter<StringT>("ERROR_MSG",new StringT("")));
           }
           if ((functionManager != null) && (functionManager.isDestroyed() == false) && (functionManager.getState().getStateString().equals(HCALStates.PAUSED.toString()))) {

--- a/src/rcms/fm/app/level1/HCALParameters.java
+++ b/src/rcms/fm/app/level1/HCALParameters.java
@@ -50,6 +50,7 @@ public class HCALParameters extends ParameterSet<FunctionManagerParameter> {
 
 		this.put( new FunctionManagerParameter<DoubleT>  ("COMPLETION"                       ,  new DoubleT(-1)        ,  FunctionManagerParameter.Exported.READONLY) );  // Completion meter
 		this.put( new FunctionManagerParameter<DoubleT>  ("PROGRESS"                         ,  new DoubleT(-1)        ,  FunctionManagerParameter.Exported.READONLY) );  // Completion meter
+		this.put( new FunctionManagerParameter<IntegerT>  ("CONFIG_TIME"                      ,  new IntegerT(-1)       ,  FunctionManagerParameter.Exported.READONLY) );  // Time taken to configure HCAL (in sec) 
 
 		this.put( new FunctionManagerParameter<StringT>  ("FED_ENABLE_MASK"                  ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // FED enable mask, typically handed to us by the level0
 		this.put( new FunctionManagerParameter<StringT>  ("STATE"                            ,  new StringT("")        ,  FunctionManagerParameter.Exported.READONLY) );  // State the Function Manager is currently in


### PR DESCRIPTION
Implements #418 .
Tested at P5: http://cmsrc-srv:9500/RunInfoServlet/?runNumber=317633
LV1 config time published in DB: 267 s
Configuration time in log:    261 s [1]

There are a few second differences, but is good enough.

[1]
```
 2018-06-09 12:40:06 and 612 ms : cms.hcalpro.rcms.fm.app.level1.HCALlevelOneEventHandler
      INFO [HCAL LVL1 HCAL_LEVEL_1] Executing configureAction
 2018-06-09 12:44:33 and 973 ms : cms.hcalpro.rcms.fm.app.level1.HCALFunctionManager
      INFO [HCAL HCAL_LEVEL_1]: Total progress is 1.0. Done configuring. Stopping ProgressThread.
```